### PR TITLE
feat: add workflow to validate PR titles against conventional commits

### DIFF
--- a/.github/workflows/validate_pr_title.yaml
+++ b/.github/workflows/validate_pr_title.yaml
@@ -1,0 +1,26 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate PR title follows conventional commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            build
+            perf
+          requireScope: false


### PR DESCRIPTION
Add GitHub Actions workflow (.github/workflows/validate_pr_title.yaml) to enforce conventional-commit PR titles (feat|fix|docs|chore|refactor|test|ci|build|perf).

