### PR TITLE
feat: Add chart artifact attachment to GitHub Releases

### DIFF
--- a/.github/workflows/_reusable-charts-cicd.yaml
+++ b/.github/workflows/_reusable-charts-cicd.yaml
@@ -27,6 +27,10 @@ on:
         description: "Run Kubernetes deployment test"
         type: boolean
         default: false
+      release-tag:
+        description: "The git tag of the release to attach the chart to"
+        type: string
+        required: false
 
 jobs:
   test-deployment:
@@ -178,6 +182,35 @@ jobs:
       - name: Check DevSpace Config Syntax - ${{ inputs.chart-name }}
         run: |
           devspace list profiles
+
+  attach-chart-to-release:
+    name: Attach Chart to Release - ${{ inputs.chart-name }}
+    runs-on: ubuntu-24.04
+    needs: validate-chart
+    if: ${{ inputs.release-tag != '' }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.chart-path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Chart Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.chart-name }}-${{ github.sha }}
+          path: ${{ inputs.chart-path }}
+
+      - name: Upload Chart to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_TAG="${{ inputs.release-tag }}"
+          CHART_FILE=$(ls ${{ inputs.chart-name }}-*.tgz | head -n 1)
+          
+          echo "Uploading $CHART_FILE to release $RELEASE_TAG"
+          gh release upload "$RELEASE_TAG" "$CHART_FILE" --clobber
+          echo "✓ Chart attached to release: $RELEASE_TAG"
 
   deploy-chart:
     name: Deploy Chart to Registry - ${{ inputs.chart-name }}

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -121,3 +121,4 @@ jobs:
       upload-artifact: ${{ fromJSON(needs.release-please.outputs.rp_outputs)[format('{0}--release_created', matrix.chart.path)] == 'true' }}
       deploy-to-registry: ${{ fromJSON(needs.release-please.outputs.rp_outputs)[format('{0}--release_created', matrix.chart.path)] == 'true' }}
       run-deployment-test: false # deployments already tested in validate-charts job
+      release-tag: ${{ fromJSON(needs.release-please.outputs.rp_outputs)[format('{0}--tag_name', matrix.chart.path)] }}


### PR DESCRIPTION
This PR adds functionality to automatically attach packaged Helm charts (`.tgz` files) to their corresponding GitHub Releases created by Release Please.

**Changes:**
- Added `release-tag` input parameter to `_reusable-charts-cicd.yaml`
- Added new `attach-chart-to-release` job that:
  - Downloads the packaged chart artifact
  - Uploads it to the GitHub Release specified by the release tag
  - Only runs when a release tag is provided
- Updated main-push.yaml to pass the release tag from Release Please outputs to the reusable workflow

**Benefits:**
- Users can now download Helm charts directly from GitHub Releases
- Charts are automatically attached during the release process
- No manual intervention required