### PR TITLE
fix: add explicit MCP server path for Ark 0.1.50 compatibility

### DIFF
--- a/agents/noah/chart/templates/mcpserver.yaml
+++ b/agents/noah/chart/templates/mcpserver.yaml
@@ -14,6 +14,9 @@ spec:
       serviceRef:
         name: {{ .Values.service.name }}
         port: "http"
+        {{- if .Values.mcpServer.path }}
+        path: {{ .Values.mcpServer.path }}
+        {{- end }}
   timeout: {{ .Values.mcpServer.timeout }}
   transport: {{ .Values.mcpServer.transport }}
   description: {{ .Values.mcpServer.description | quote }}

--- a/agents/noah/chart/values.yaml
+++ b/agents/noah/chart/values.yaml
@@ -22,6 +22,7 @@ mcpServer:
   enabled: true
   timeout: "60s"
   transport: http
+  path: /mcp
   description: "Noah MCP server providing runtime administration tools"
 
 # Resources

--- a/docs/content/agents/noah.mdx
+++ b/docs/content/agents/noah.mdx
@@ -35,6 +35,11 @@ Noah is the Agent who runs the Ark. Noah can answers questions on how Ark works,
 "What charts are available in the repository?"
 ```
 
+## Requirements
+
+- **Ark 0.1.50+**: Noah requires Ark version 0.1.50 or later due to MCP server path configuration changes
+- For older Ark versions, set `mcpServer.path: ""` in your Helm values to disable explicit path configuration
+
 ## Quick Start
 
 ### Installation

--- a/docs/content/services/ark-sandbox.mdx
+++ b/docs/content/services/ark-sandbox.mdx
@@ -15,6 +15,11 @@ ARK Sandbox provides:
 - **Warm Pools** - Pre-created sandboxes for instant availability
 - **PVC Mounting** - Share files between workflows and sandboxes
 
+## Requirements
+
+- **Ark 0.1.50+**: ARK Sandbox requires Ark version 0.1.50 or later due to MCP server path configuration changes
+- For older Ark versions, set `mcpServer.path: ""` in your Helm values
+
 ## Install
 
 ```bash

--- a/services/ark-sandbox/chart/templates/mcpserver.yaml
+++ b/services/ark-sandbox/chart/templates/mcpserver.yaml
@@ -15,6 +15,9 @@ spec:
       serviceRef:
         name: {{ .Values.service.name }}
         port: "http"
+        {{- if .Values.mcpServer.path }}
+        path: {{ .Values.mcpServer.path }}
+        {{- end }}
   transport: http
   pollInterval: {{ .Values.mcpServer.pollInterval }}
   timeout: {{ .Values.mcpServer.timeout }}

--- a/services/ark-sandbox/chart/values.yaml
+++ b/services/ark-sandbox/chart/values.yaml
@@ -61,6 +61,7 @@ mcpServer:
   description: "ARK Sandbox MCP server for executing commands in sandbox containers"
   pollInterval: "1m"
   timeout: "120s"
+  path: /mcp
 
 # Sandbox defaults - used for documentation and reference
 sandboxDefaults:


### PR DESCRIPTION
## Summary
- Add configurable `mcpServer.path` field to noah and ark-sandbox charts (default: `/mcp`)
- Update MCPServer templates to include path when set
- Document Ark 0.1.50+ requirement in docs
- Users on older Ark versions can set `mcpServer.path: ""` for backwards compatibility

Ark 0.1.50 no longer auto-appends `/mcp` to MCP server addresses, requiring explicit path configuration.