### PR TITLE
fix: add file-gateway to release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -58,6 +58,14 @@
       "extra-files": [
         "chart/Chart.yaml"
       ]
+    },
+    "services/file-gateway": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm",
+      "package-name": "file-gateway",
+      "extra-files": [
+        "chart/Chart.yaml"
+      ]
     }
   }
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -6,5 +6,6 @@
   "services/a2a-inspector": "0.1.1",
   "services/mcp-inspector": "0.1.1",
   "services/ark-sandbox": "0.1.1",
-  "agents/noah": "0.1.7"
+  "agents/noah": "0.1.7",
+  "services/file-gateway": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Adds `services/file-gateway` to release-please configuration
- Sets initial version to 0.1.0