### PR TITLE
fix: add file-gateway to CI workflow matrices

### DIFF
--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -50,6 +50,8 @@ jobs:
           - { name: ark-sandbox, path: services/ark-sandbox, namespace: default, run-deployment-test: false }
           # disable noah deployment tests for PRs to avoid hitting 5m limit
           - { name: noah, path: agents/noah, namespace: noah, run-deployment-test: false }
+          # disable file-gateway deployment tests for PRs to avoid hitting 5m limit
+          - { name: file-gateway, path: services/file-gateway, namespace: default, run-deployment-test: false }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}
@@ -156,6 +158,7 @@ jobs:
           - { name: mcp-inspector, path: services/mcp-inspector, namespace: default }
           - { name: ark-sandbox, path: services/ark-sandbox, namespace: default }
           - { name: noah, path: agents/noah, namespace: noah }
+          - { name: file-gateway, path: services/file-gateway, namespace: default }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,7 @@ jobs:
         service:
           - { name: noah, path: agents/noah }
           - { name: ark-sandbox, path: services/ark-sandbox }
+          - { name: file-api, path: services/file-gateway/services/file-api }
     uses: ./.github/workflows/_reusable-docker-cicd.yaml
     with:
       service-name: ${{ matrix.service.name }}
@@ -47,6 +48,8 @@ jobs:
           - { name: ark-sandbox, path: services/ark-sandbox, namespace: default, run-deployment-test: false }
           # disable noah deployment tests for PRs to avoid hitting 5m limit
           - { name: noah, path: agents/noah, namespace: noah, run-deployment-test: false }
+          # disable file-gateway deployment tests for PRs to avoid hitting 5m limit
+          - { name: file-gateway, path: services/file-gateway, namespace: default, run-deployment-test: false }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}


### PR DESCRIPTION
## Summary
- Adds file-gateway to validate-charts and deploy-charts matrices in main-push.yaml
- Adds file-gateway to build-docker-images and validate-charts matrices in pull-request.yaml
- Fixes "not found" error when installing file-gateway via ark CLI (chart was never published)