### PR TITLE
feat: add executor-claude-agent service for Claude Agent SDK integration

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -138,6 +138,33 @@
       }
     },
     {
+      "name": "executor-claude-agent",
+      "type": "service",
+      "displayName": "Claude Agent Executor",
+      "description": "ARK ExecutionEngine using Claude Agent SDK for agentic task execution with Anthropic API and AWS Bedrock support",
+      "version": "0.1.0",
+      "author": "ARK Marketplace",
+      "homepage": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "repository": "https://github.com/mckinsey/agents-at-scale-marketplace",
+      "license": "Apache-2.0",
+      "tags": ["executor", "claude", "anthropic", "bedrock", "agent-sdk", "ai"],
+      "category": "executors",
+      "icon": "https://example.com/claude-agent-icon.png",
+      "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/executor-claude-agent/",
+      "support": {
+        "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
+      },
+      "ark": {
+        "chartPath": "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/executor-claude-agent",
+        "namespace": "default",
+        "helmReleaseName": "executor-claude-agent",
+        "installArgs": ["--create-namespace"],
+        "k8sServiceName": "executor-claude-agent",
+        "k8sServicePort": 8000,
+        "k8sDeploymentName": "executor-claude-agent"
+      }
+    },
+    {
       "name": "noah",
       "type": "agent",
       "displayName": "Noah",

--- a/openspec/changes/2026-03-31-session-scheduling/proposal.md
+++ b/openspec/changes/2026-03-31-session-scheduling/proposal.md
@@ -1,0 +1,199 @@
+## Why
+
+The Claude Code executor runs as a single Deployment — all sessions share the same pod. Claude Agent SDK sessions need filesystem access (git repos, workspace files), and concurrent sessions on a shared pod fight over locks, ports, and workspace state.
+
+Session scheduling lets the executor create a dedicated Deployment per session. Each session gets its own pod with its own PVC, eliminating contention.
+
+## Design Principle
+
+Follow conventions from common Kubernetes projects, in particular Argo Workflows. Argo solves a similar problem — scheduling workflow pods from a WorkflowTemplate. A session for an agent is analogous to a workflow for a template. Where Argo has an established pattern (conventional ConfigMap names, volumeClaimTemplates, direct pod IP communication), we use it.
+
+The executor remains a service (FastAPI, A2A endpoint), but with session scheduling it also behaves like an operator — it watches a ConfigMap for configuration and schedules child resources (Deployments, PVCs) in response to incoming sessions. Similar to how the Argo workflow-controller is a service that manages workflow pod lifecycles.
+
+## What Changes
+
+### ExecutionEngine CRD
+
+No CRD changes. Session scheduling is an executor concern, not a platform concern.
+
+### Executor Configuration
+
+Inspired by Argo Workflows, where the workflow-controller reads a conventionally-named ConfigMap (`workflow-controller-configmap`). Argo allows overriding the name via the `--configmap` CLI flag.
+
+We follow the same pattern:
+
+- **Default ConfigMap name:** `executor-claude-agent-config` (convention, matches the Deployment name)
+- **Override via env var:** `EXECUTOR_CONFIG_MAP` on the executor Deployment
+
+The executor reads this ConfigMap at startup and watches it for changes.
+
+### ConfigMap Schema
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: executor-claude-agent-config
+data:
+  # Scheduling mode.
+  # "none": single pod, all sessions share it (current behavior).
+  # "session": apply the session template below to create a dedicated
+  #   Deployment per session.
+  scheduling: "session"
+
+  # How long after the last A2A message before the session's Deployment
+  # is deleted. The executor resets this timer on each message.
+  sessionExpiryTTL: "24h"
+
+  # When to delete PVCs created from volumeClaimTemplates.
+  # Follows Argo Workflows' volumeClaimGC.strategy convention
+  # (OnWorkflowCompletion / OnWorkflowSuccess). Sessions don't have a
+  # completion event — they expire via TTL — so the strategies are:
+  #   "OnSessionExpiry" (default): delete PVCs when the session TTL
+  #     expires, along with the Deployment.
+  #   "Never": retain PVCs after session cleanup. Useful for debugging
+  #     or resuming sessions against the same workspace.
+  # The executor identifies which PVCs to delete via the
+  # ark.mckinsey.com/session-id label — all session resources
+  # (Deployments, PVCs) share this label.
+  volumeClaimGC: "OnSessionExpiry"
+
+  # Session template. Applied once per session when scheduling is
+  # "session". Contains a Deployment spec and optional volumeClaimTemplates,
+  # following the Argo Workflows pattern where volumeClaimTemplates sit
+  # alongside the pod template, linked by volume name.
+  #
+  # Template rendering:
+  #   The executor renders Go template variables before applying:
+  #     {{.SessionID}}  — unique session identifier
+  #     {{.EngineName}} — ExecutionEngine resource name
+  #     {{.Namespace}}  — ExecutionEngine namespace
+  #
+  # Labels and ownership:
+  #   The executor adds to every resource it creates:
+  #     label: ark.mckinsey.com/session-id={{.SessionID}}
+  #     label: ark.mckinsey.com/engine={{.EngineName}}
+  #     ownerReferences: pointing to the ExecutionEngine resource
+  #
+  # Validation:
+  #   The executor validates the deployment against the Kubernetes API
+  #   schema before applying.
+  #
+  # Networking:
+  #   No Service is created. The executor finds session pods by label
+  #   and communicates via pod IP + containerPort — same pattern as Argo
+  #   Workflows, which talks to workflow step pods directly without
+  #   creating Services.
+  #
+  # Volume binding:
+  #   When volumeClaimTemplates is present, the executor creates the
+  #   PVC and injects a matching entry into the Deployment's
+  #   spec.template.spec.volumes, linking it to the container's
+  #   volumeMounts by name ("workspace" in the example below).
+  sessionTemplate: |
+    deployment:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: session-{{.SessionID}}
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            ark.mckinsey.com/session-id: "{{.SessionID}}"
+        template:
+          metadata:
+            labels:
+              ark.mckinsey.com/session-id: "{{.SessionID}}"
+              ark.mckinsey.com/engine: "{{.EngineName}}"
+          spec:
+            containers:
+              - name: claude-agent
+                image: ghcr.io/mckinsey/executor-claude-agent:latest
+                ports:
+                  - containerPort: 8000
+                resources:
+                  requests:
+                    memory: "512Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "2Gi"
+                    cpu: "1000m"
+                volumeMounts:
+                  - name: workspace
+                    mountPath: /workspace
+
+    # PVC templates created per session, linked to the Deployment by
+    # volume name. The name "workspace" here matches the volumeMounts
+    # name in the container above. The executor creates the PVC, adds
+    # it to the Deployment's volumes, and binds them — same as
+    # StatefulSet and Argo Workflows volumeClaimTemplates.
+    volumeClaimTemplates:
+      - metadata:
+          name: workspace
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+
+    # --- Alternative: attach an existing PVC instead of creating one ---
+    #
+    # To use a pre-existing PVC (e.g. a shared dataset or pre-provisioned
+    # volume), omit volumeClaimTemplates and reference the PVC directly
+    # in the Deployment's volumes. The executor will not create or delete
+    # the PVC — volumeClaimGC only applies to PVCs created from
+    # volumeClaimTemplates.
+    #
+    # deployment:
+    #   ...
+    #   spec:
+    #     template:
+    #       spec:
+    #         containers:
+    #           - name: claude-agent
+    #             volumeMounts:
+    #               - name: workspace
+    #                 mountPath: /workspace
+    #         volumes:
+    #           - name: workspace
+    #             persistentVolumeClaim:
+    #               claimName: my-existing-pvc
+```
+
+### Executor Behavior
+
+**scheduling: none (default):** Current behavior. Single Deployment, all sessions share it. The executor handles requests directly via `/execute`.
+
+**scheduling: session:** When the executor receives an A2A conversation:
+
+1. **Check for existing session.** Label selector: `ark.mckinsey.com/session-id={sessionId}`.
+2. **If none exists**, render `sessionTemplate`, validate against K8s API schema, and apply:
+   - PVCs from `volumeClaimTemplates` (if present), linked to the Deployment by volume name
+   - Deployment from `deployment`, with PVC volume injected
+   - All resources get ownerReferences and session labels
+3. **Find the session pod** by label, get its IP from Pod status, proxy the A2A message to `{podIP}:{containerPort}`.
+4. **Wait for readiness** if the pod is not yet ready — watch `Deployment.status.readyReplicas`.
+5. **Reset the TTL timer** on each message.
+6. **On TTL expiry:**
+   - Delete the Deployment (label selector: `ark.mckinsey.com/session-id`)
+   - If `volumeClaimGC` is `OnSessionExpiry`, also delete PVCs with the same label
+   - If `volumeClaimGC` is `Never`, PVCs are retained
+
+### RBAC
+
+The executor needs permissions to create/delete Deployments, read Pods (for IP and status), and create/delete PVCs. Document in the Helm chart with comments explaining why.
+
+## Impact
+
+- `services/executor-claude-agent/src/` — session scheduling logic, ConfigMap watcher, template renderer
+- `services/executor-claude-agent/chart/` — RBAC roles, ConfigMap template, env var for config override
+- No changes to the Ark core repo or ExecutionEngine CRD
+
+## Non-goals
+
+- Lifecycle hooks via init containers (follow-on story)
+- Network policies
+- Integration test port collisions (separate bug)
+- Implementation roadmap / phasing

--- a/openspec/changes/2026-03-31-session-scheduling/proposal.md
+++ b/openspec/changes/2026-03-31-session-scheduling/proposal.md
@@ -2,13 +2,13 @@
 
 The Claude Code executor runs as a single Deployment — all sessions share the same pod. Claude Agent SDK sessions need filesystem access (git repos, workspace files), and concurrent sessions on a shared pod fight over locks, ports, and workspace state.
 
-Session scheduling lets the executor create a dedicated Deployment per session. Each session gets its own pod with its own PVC, eliminating contention.
+Session scheduling lets the executor create a dedicated sandbox per session using [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox). Each session gets its own pod with its own PVC, stable DNS, and network isolation.
 
 ## Design Principle
 
-Follow conventions from common Kubernetes projects, in particular Argo Workflows. Argo solves a similar problem — scheduling workflow pods from a WorkflowTemplate. A session for an agent is analogous to a workflow for a template. Where Argo has an established pattern (conventional ConfigMap names, volumeClaimTemplates, direct pod IP communication), we use it.
+Use `kubernetes-sigs/agent-sandbox` (v0.2.1, SIG Apps) rather than building custom pod lifecycle management. agent-sandbox provides a `Sandbox` CRD purpose-built for isolated, stateful, singleton workloads — exactly our use case. It handles pod lifecycle, persistent storage, stable DNS, network isolation, warm pools, and reconciliation.
 
-The executor remains a service (FastAPI, A2A endpoint), but with session scheduling it also behaves like an operator — it watches a ConfigMap for configuration and schedules child resources (Deployments, PVCs) in response to incoming sessions. Similar to how the Argo workflow-controller is a service that manages workflow pod lifecycles.
+Where agent-sandbox doesn't cover our needs (idle TTL), we layer minimal executor logic on top. Configuration follows the Argo Workflows convention of a conventionally-named ConfigMap.
 
 ## What Changes
 
@@ -16,18 +16,19 @@ The executor remains a service (FastAPI, A2A endpoint), but with session schedul
 
 No CRD changes. Session scheduling is an executor concern, not a platform concern.
 
+### Prerequisites
+
+agent-sandbox must be installed in the cluster:
+
+```bash
+export VERSION="v0.2.1"
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/manifest.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/extensions.yaml
+```
+
 ### Executor Configuration
 
-Inspired by Argo Workflows, where the workflow-controller reads a conventionally-named ConfigMap (`workflow-controller-configmap`). Argo allows overriding the name via the `--configmap` CLI flag.
-
-We follow the same pattern:
-
-- **Default ConfigMap name:** `executor-claude-agent-config` (convention, matches the Deployment name)
-- **Override via env var:** `EXECUTOR_CONFIG_MAP` on the executor Deployment
-
-The executor reads this ConfigMap at startup and watches it for changes.
-
-### ConfigMap Schema
+Follows the Argo Workflows pattern — conventionally-named ConfigMap (`executor-claude-agent-config`), overridable via `EXECUTOR_CONFIG_MAP` env var.
 
 ```yaml
 apiVersion: v1
@@ -35,99 +36,40 @@ kind: ConfigMap
 metadata:
   name: executor-claude-agent-config
 data:
-  # Scheduling mode.
-  # "none": single pod, all sessions share it (current behavior).
-  # "session": apply the session template below to create a dedicated
-  #   Deployment per session.
-  scheduling: "session"
+  # "none": single pod (current behavior).
+  # "sandbox": create a Sandbox CR per session via agent-sandbox.
+  scheduling: "sandbox"
 
-  # How long after the last A2A message before the session's Deployment
-  # is deleted. The executor resets this timer on each message.
-  sessionExpiryTTL: "24h"
+  # How long after the last A2A message before shutdown.
+  # The executor rolls forward the Sandbox's spec.shutdownTime on each message.
+  sessionIdleTTL: "24h"
 
-  # When to delete PVCs created from volumeClaimTemplates.
-  # Follows Argo Workflows' volumeClaimGC.strategy convention
-  # (OnWorkflowCompletion / OnWorkflowSuccess). Sessions don't have a
-  # completion event — they expire via TTL — so the strategies are:
-  #   "OnSessionExpiry" (default): delete PVCs when the session TTL
-  #     expires, along with the Deployment.
-  #   "Never": retain PVCs after session cleanup. Useful for debugging
-  #     or resuming sessions against the same workspace.
-  # The executor identifies which PVCs to delete via the
-  # ark.mckinsey.com/session-id label — all session resources
-  # (Deployments, PVCs) share this label.
-  volumeClaimGC: "OnSessionExpiry"
+  # Maps to agent-sandbox shutdownPolicy: "Delete" (default) or "Retain".
+  shutdownPolicy: "Delete"
 
-  # Session template. Applied once per session when scheduling is
-  # "session". Contains a Deployment spec and optional volumeClaimTemplates,
-  # following the Argo Workflows pattern where volumeClaimTemplates sit
-  # alongside the pod template, linked by volume name.
-  #
-  # Template rendering:
-  #   The executor renders Go template variables before applying:
-  #     {{.SessionID}}  — unique session identifier
-  #     {{.EngineName}} — ExecutionEngine resource name
-  #     {{.Namespace}}  — ExecutionEngine namespace
-  #
-  # Labels and ownership:
-  #   The executor adds to every resource it creates:
-  #     label: ark.mckinsey.com/session-id={{.SessionID}}
-  #     label: ark.mckinsey.com/engine={{.EngineName}}
-  #     ownerReferences: pointing to the ExecutionEngine resource
-  #
-  # Validation:
-  #   The executor validates the deployment against the Kubernetes API
-  #   schema before applying.
-  #
-  # Networking:
-  #   No Service is created. The executor finds session pods by label
-  #   and communicates via pod IP + containerPort — same pattern as Argo
-  #   Workflows, which talks to workflow step pods directly without
-  #   creating Services.
-  #
-  # Volume binding:
-  #   When volumeClaimTemplates is present, the executor creates the
-  #   PVC and injects a matching entry into the Deployment's
-  #   spec.template.spec.volumes, linking it to the container's
-  #   volumeMounts by name ("workspace" in the example below).
-  sessionTemplate: |
-    deployment:
-      apiVersion: apps/v1
-      kind: Deployment
+  # Standard agent-sandbox SandboxSpec. The image must run the A2A server.
+  sandboxSpec: |
+    podTemplate:
       metadata:
-        name: session-{{.SessionID}}
+        labels:
+          ark.mckinsey.com/session-id: "{{.SessionID}}"
+          ark.mckinsey.com/engine: "{{.EngineName}}"
       spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            ark.mckinsey.com/session-id: "{{.SessionID}}"
-        template:
-          metadata:
-            labels:
-              ark.mckinsey.com/session-id: "{{.SessionID}}"
-              ark.mckinsey.com/engine: "{{.EngineName}}"
-          spec:
-            containers:
-              - name: claude-agent
-                image: ghcr.io/mckinsey/executor-claude-agent:latest
-                ports:
-                  - containerPort: 8000
-                resources:
-                  requests:
-                    memory: "512Mi"
-                    cpu: "250m"
-                  limits:
-                    memory: "2Gi"
-                    cpu: "1000m"
-                volumeMounts:
-                  - name: workspace
-                    mountPath: /workspace
-
-    # PVC templates created per session, linked to the Deployment by
-    # volume name. The name "workspace" here matches the volumeMounts
-    # name in the container above. The executor creates the PVC, adds
-    # it to the Deployment's volumes, and binds them — same as
-    # StatefulSet and Argo Workflows volumeClaimTemplates.
+        containers:
+          - name: claude-agent
+            image: ghcr.io/mckinsey/executor-claude-agent:latest
+            ports:
+              - containerPort: 8000
+            resources:
+              requests:
+                memory: "512Mi"
+                cpu: "250m"
+              limits:
+                memory: "2Gi"
+                cpu: "1000m"
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
     volumeClaimTemplates:
       - metadata:
           name: workspace
@@ -137,63 +79,50 @@ data:
           resources:
             requests:
               storage: 10Gi
-
-    # --- Alternative: attach an existing PVC instead of creating one ---
-    #
-    # To use a pre-existing PVC (e.g. a shared dataset or pre-provisioned
-    # volume), omit volumeClaimTemplates and reference the PVC directly
-    # in the Deployment's volumes. The executor will not create or delete
-    # the PVC — volumeClaimGC only applies to PVCs created from
-    # volumeClaimTemplates.
-    #
-    # deployment:
-    #   ...
-    #   spec:
-    #     template:
-    #       spec:
-    #         containers:
-    #           - name: claude-agent
-    #             volumeMounts:
-    #               - name: workspace
-    #                 mountPath: /workspace
-    #         volumes:
-    #           - name: workspace
-    #             persistentVolumeClaim:
-    #               claimName: my-existing-pvc
 ```
 
 ### Executor Behavior
 
-**scheduling: none (default):** Current behavior. Single Deployment, all sessions share it. The executor handles requests directly via `/execute`.
+**scheduling: none (default):** Current behavior. Single pod, all sessions share it.
 
-**scheduling: session:** When the executor receives an A2A conversation:
+**scheduling: sandbox:** When the executor receives an A2A conversation:
 
-1. **Check for existing session.** Label selector: `ark.mckinsey.com/session-id={sessionId}`.
-2. **If none exists**, render `sessionTemplate`, validate against K8s API schema, and apply:
-   - PVCs from `volumeClaimTemplates` (if present), linked to the Deployment by volume name
-   - Deployment from `deployment`, with PVC volume injected
-   - All resources get ownerReferences and session labels
-3. **Find the session pod** by label, get its IP from Pod status, proxy the A2A message to `{podIP}:{containerPort}`.
-4. **Wait for readiness** if the pod is not yet ready — watch `Deployment.status.readyReplicas`.
-5. **Reset the TTL timer** on each message.
-6. **On TTL expiry:**
-   - Delete the Deployment (label selector: `ark.mckinsey.com/session-id`)
-   - If `volumeClaimGC` is `OnSessionExpiry`, also delete PVCs with the same label
-   - If `volumeClaimGC` is `Never`, PVCs are retained
+1. **Check for existing Sandbox.** Label selector: `ark.mckinsey.com/session-id={sessionId}`.
+2. **If none exists**, render `sandboxSpec` and create a `Sandbox` CR with `shutdownTime` set to `now + sessionIdleTTL`.
+3. **Wait for Ready condition** on the Sandbox CR.
+4. **Proxy the A2A message** to `session-{sessionId}.{namespace}.svc.cluster.local:8000` (stable DNS from agent-sandbox).
+5. **Roll forward `shutdownTime`** on each message.
+6. **On expiry**, agent-sandbox controller handles cleanup based on `shutdownPolicy`.
+
+### Warm Pool (optional)
+
+For faster session startup, deploy a `SandboxTemplate` and `SandboxWarmPool`. The executor creates a `SandboxClaim` instead of a `Sandbox`, claiming a pre-warmed pod from the pool.
 
 ### RBAC
 
-The executor needs permissions to create/delete Deployments, read Pods (for IP and status), and create/delete PVCs. Document in the Helm chart with comments explaining why.
+The executor needs Sandbox/SandboxClaim CRUD permissions. Pod and PVC management is handled by the agent-sandbox controller.
+
+## What We Get from agent-sandbox
+
+| Concern | agent-sandbox |
+|---|---|
+| Pod lifecycle | Sandbox controller |
+| Crash recovery | Controller reconciliation |
+| Persistent storage | `volumeClaimTemplates` |
+| Stable networking | Service + DNS per Sandbox |
+| Warm pools | `SandboxWarmPool` + `SandboxClaim` |
+| Network isolation | Managed NetworkPolicy |
+| Pause/resume | `replicas: 0/1` |
+| Shutdown | `shutdownTime` + `shutdownPolicy` |
 
 ## Impact
 
-- `services/executor-claude-agent/src/` — session scheduling logic, ConfigMap watcher, template renderer
-- `services/executor-claude-agent/chart/` — RBAC roles, ConfigMap template, env var for config override
+- `services/executor-claude-agent/src/` — sandbox creation, ConfigMap watcher, A2A proxy logic
+- `services/executor-claude-agent/chart/` — RBAC for Sandbox CRs, ConfigMap template, agent-sandbox dependency
 - No changes to the Ark core repo or ExecutionEngine CRD
 
 ## Non-goals
 
 - Lifecycle hooks via init containers (follow-on story)
-- Network policies
-- Integration test port collisions (separate bug)
+- Custom SandboxTemplate + NetworkPolicy configuration (follow-on)
 - Implementation roadmap / phasing

--- a/services/executor-claude-agent/Dockerfile
+++ b/services/executor-claude-agent/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY src/ ./src/
+
+# Set Python path
+ENV PYTHONPATH=/app/src
+ENV PYTHONUNBUFFERED=1
+
+# Default configuration
+ENV PORT=8000
+ENV HOST=0.0.0.0
+ENV CLAUDE_MODEL=claude-sonnet-4-20250514
+ENV CLAUDE_MAX_TURNS=10
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+EXPOSE 8000
+
+CMD ["python", "-m", "claude_executor.app"]

--- a/services/executor-claude-agent/Dockerfile
+++ b/services/executor-claude-agent/Dockerfile
@@ -1,16 +1,19 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies and uv
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.local/bin:$PATH"
 
 # Copy requirements first for layer caching
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --system --no-cache -r requirements.txt
 
 # Copy application code
 COPY src/ ./src/

--- a/services/executor-claude-agent/README.md
+++ b/services/executor-claude-agent/README.md
@@ -1,0 +1,168 @@
+# Executor Claude Agent
+
+ARK ExecutionEngine implementation using Claude Agent SDK for agentic task execution.
+
+## Overview
+
+This executor enables ARK to use Claude models (via Anthropic API or AWS Bedrock) as a native execution engine. Agents created with this executor can leverage Claude's capabilities for code generation, analysis, and multi-turn conversations.
+
+## Features
+
+- **Dual Provider Support**: Works with both Anthropic API and AWS Bedrock
+- **ARK Native**: Implements the ExecutionEngine protocol for seamless integration
+- **Agentic Capabilities**: Supports Claude Agent SDK for tool use and multi-turn execution
+- **OpenTelemetry**: Built-in observability support
+
+## Installation
+
+### Via Helm
+
+```bash
+helm install executor-claude-agent oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/executor-claude-agent
+```
+
+### Via ARK CLI
+
+```bash
+ark marketplace install executor-claude-agent
+```
+
+## Configuration
+
+### Using Anthropic API
+
+Create a secret with your API key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-credentials
+type: Opaque
+stringData:
+  api-key: "your-api-key"
+```
+
+Configure in values:
+
+```yaml
+anthropicApiKey:
+  existingSecret: "anthropic-credentials"
+  existingSecretKey: "api-key"
+```
+
+### Using AWS Bedrock
+
+Create a secret with AWS credentials:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-bedrock-credentials
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: "your-access-key"
+  AWS_SECRET_ACCESS_KEY: "your-secret-key"
+  AWS_SESSION_TOKEN: "optional-session-token"
+  AWS_REGION: "us-east-1"
+```
+
+The executor auto-detects Bedrock when AWS credentials are present and no Anthropic API key is configured.
+
+## Creating Agents
+
+Once the executor is installed, create agents that use it:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: claude-bedrock
+spec:
+  type: bedrock
+  model:
+    value: "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+  config:
+    bedrock:
+      region:
+        value: "us-east-1"
+      accessKeyId:
+        valueFrom:
+          secretKeyRef:
+            name: aws-bedrock-credentials
+            key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        valueFrom:
+          secretKeyRef:
+            name: aws-bedrock-credentials
+            key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: claude-developer
+spec:
+  description: "Expert Python developer agent"
+  executionEngine:
+    name: executor-claude-agent
+  modelRef:
+    name: claude-bedrock
+  prompt: |
+    You are an expert Python developer. Write clean, well-documented code.
+    Follow best practices and provide explanations for your implementations.
+```
+
+## Querying Agents
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: my-query
+spec:
+  type: user
+  input: "Write a function to calculate fibonacci numbers"
+  targets:
+    - name: claude-developer
+      type: agent
+```
+
+## Supported Models
+
+| Model Name | Bedrock Model ID |
+|------------|------------------|
+| claude-sonnet-4-20250514 | us.anthropic.claude-sonnet-4-20250514-v1:0 |
+| claude-3-5-sonnet | us.anthropic.claude-3-5-sonnet-20241022-v2:0 |
+| claude-3-sonnet | us.anthropic.claude-3-sonnet-20240229-v1:0 |
+| claude-3-haiku | us.anthropic.claude-3-haiku-20240307-v1:0 |
+| claude-3-opus | us.anthropic.claude-3-opus-20240229-v1:0 |
+
+## Architecture
+
+```
+ARK Query → Agent → ExecutionEngine (executor-claude-agent) → Bedrock/Anthropic API → Response
+```
+
+The executor:
+1. Receives requests from ARK's broker
+2. Translates to Claude's message format
+3. Calls the appropriate provider (Bedrock or Anthropic)
+4. Returns responses in ARK's format
+
+## Values Reference
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Docker image repository | `ghcr.io/mckinsey/executor-claude-agent` |
+| `image.tag` | Docker image tag | `""` (uses appVersion) |
+| `claude.model` | Default Claude model | `claude-sonnet-4-20250514` |
+| `claude.maxTurns` | Max agentic turns | `10` |
+| `anthropicApiKey.existingSecret` | Secret name for API key | `""` |
+| `otel.enabled` | Enable OpenTelemetry | `false` |
+| `executionEngine.enabled` | Create ExecutionEngine CRD | `true` |
+| `executionEngine.name` | ExecutionEngine name | `executor-claude-agent` |
+
+## License
+
+Apache-2.0

--- a/services/executor-claude-agent/chart/Chart.yaml
+++ b/services/executor-claude-agent/chart/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: executor-claude-agent
+description: ARK ExecutionEngine using Claude Agent SDK for agentic task execution
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - ark
+  - claude
+  - agent
+  - execution-engine
+  - ai
+maintainers:
+  - name: ARK Team

--- a/services/executor-claude-agent/chart/templates/_helpers.tpl
+++ b/services/executor-claude-agent/chart/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "executor-claude.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "executor-claude.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "executor-claude.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "executor-claude.labels" -}}
+helm.sh/chart: {{ include "executor-claude.chart" . }}
+{{ include "executor-claude.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "executor-claude.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "executor-claude.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "executor-claude.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "executor-claude.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/services/executor-claude-agent/chart/templates/deployment.yaml
+++ b/services/executor-claude-agent/chart/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "executor-claude.fullname" . }}
+  labels:
+    {{- include "executor-claude.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "executor-claude.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "executor-claude.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "executor-claude.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8000"
+            - name: CLAUDE_MODEL
+              value: {{ .Values.claude.model | quote }}
+            - name: CLAUDE_MAX_TURNS
+              value: {{ .Values.claude.maxTurns | quote }}
+            {{- if .Values.anthropicApiKey.existingSecret }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.anthropicApiKey.existingSecret }}
+                  key: {{ .Values.anthropicApiKey.existingSecretKey }}
+            {{- else if .Values.anthropicApiKey.value }}
+            - name: ANTHROPIC_API_KEY
+              value: {{ .Values.anthropicApiKey.value | quote }}
+            {{- end }}
+            {{- if .Values.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.otel.protocol | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/executor-claude-agent/chart/templates/executionengine.yaml
+++ b/services/executor-claude-agent/chart/templates/executionengine.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.executionEngine.enabled }}
+apiVersion: ark.mckinsey.com/v1prealpha1
+kind: ExecutionEngine
+metadata:
+  name: {{ .Values.executionEngine.name | default (include "executor-claude.fullname" .) }}
+  labels:
+    {{- include "executor-claude.labels" . | nindent 4 }}
+spec:
+  type: "claude"
+  address:
+    valueFrom:
+      serviceRef:
+        name: {{ include "executor-claude.fullname" . }}
+        port: {{ .Values.service.port | quote }}
+  description: {{ .Values.executionEngine.description | quote }}
+{{- end }}

--- a/services/executor-claude-agent/chart/templates/service.yaml
+++ b/services/executor-claude-agent/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "executor-claude.fullname" . }}
+  labels:
+    {{- include "executor-claude.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "executor-claude.selectorLabels" . | nindent 4 }}

--- a/services/executor-claude-agent/chart/templates/serviceaccount.yaml
+++ b/services/executor-claude-agent/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "executor-claude.serviceAccountName" . }}
+  labels:
+    {{- include "executor-claude.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/executor-claude-agent/chart/values.yaml
+++ b/services/executor-claude-agent/chart/values.yaml
@@ -1,0 +1,63 @@
+# Default values for executor-claude-agent
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mckinsey/executor-claude-agent
+  pullPolicy: IfNotPresent
+  tag: ""  # Defaults to chart appVersion
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Claude configuration
+claude:
+  model: "claude-sonnet-4-20250514"
+  maxTurns: 10
+
+# API key configuration
+anthropicApiKey:
+  # Use existing secret
+  existingSecret: ""
+  existingSecretKey: "api-key"
+  # Or provide directly (not recommended for production)
+  value: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# OpenTelemetry configuration
+otel:
+  enabled: false
+  endpoint: ""
+  protocol: "grpc"
+  serviceName: "executor-claude-agent"
+
+# ExecutionEngine CRD configuration
+executionEngine:
+  enabled: true
+  name: "executor-claude-agent"
+  description: "Claude Agent SDK executor with agentic capabilities"

--- a/services/executor-claude-agent/examples/agent-developer.yaml
+++ b/services/executor-claude-agent/examples/agent-developer.yaml
@@ -1,0 +1,74 @@
+---
+# Model configuration for Claude
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: claude-sonnet
+spec:
+  type: anthropic
+  model: claude-sonnet-4-20250514
+  credentials:
+    secretRef:
+      name: anthropic-credentials
+      key: api-key
+---
+# Developer Agent using Claude Agent SDK ExecutionEngine
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: developer
+  labels:
+    ark.mckinsey.com/agent-type: developer
+spec:
+  description: |
+    Software developer agent with full agentic capabilities.
+    Uses Claude Agent SDK for autonomous code writing, testing, and debugging.
+
+  prompt: |
+    You are an expert software developer. Your role is to:
+
+    1. Write clean, well-documented code following best practices
+    2. Create comprehensive tests for your implementations
+    3. Debug and fix issues systematically
+    4. Follow the existing codebase patterns and conventions
+
+    When given a task:
+    - First analyze the requirements and existing code
+    - Plan your implementation approach
+    - Write the code incrementally, testing as you go
+    - Ensure all tests pass before completing
+
+    You have access to file operations, code execution, and search tools.
+    Use them effectively to complete your tasks.
+
+  modelRef:
+    name: claude-sonnet
+
+  # Use Claude Agent SDK ExecutionEngine for full agentic capabilities
+  executionEngine:
+    name: executor-claude
+
+  tools:
+    # File operations
+    - type: built-in
+      name: read
+      description: Read file contents
+    - type: built-in
+      name: write
+      description: Write content to files
+    - type: built-in
+      name: edit
+      description: Edit existing files
+
+    # Code execution
+    - type: built-in
+      name: bash
+      description: Execute shell commands
+
+    # Search
+    - type: built-in
+      name: glob
+      description: Find files by pattern
+    - type: built-in
+      name: grep
+      description: Search file contents

--- a/services/executor-claude-agent/examples/agent-reviewer.yaml
+++ b/services/executor-claude-agent/examples/agent-reviewer.yaml
@@ -1,0 +1,53 @@
+---
+# Code Reviewer Agent using Claude Agent SDK ExecutionEngine
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: reviewer
+  labels:
+    ark.mckinsey.com/agent-type: reviewer
+spec:
+  description: |
+    Code review agent that analyzes code for quality, security, and best practices.
+    Uses Claude Agent SDK for thorough code analysis.
+
+  prompt: |
+    You are an expert code reviewer. Your role is to:
+
+    1. Review code changes for correctness and quality
+    2. Identify potential bugs, security vulnerabilities, and performance issues
+    3. Check adherence to coding standards and best practices
+    4. Suggest improvements and refactoring opportunities
+    5. Ensure adequate test coverage
+
+    When reviewing code:
+    - Start by understanding the context and purpose of the changes
+    - Analyze the code systematically
+    - Provide specific, actionable feedback
+    - Categorize issues by severity (critical, major, minor, suggestion)
+    - Acknowledge good practices when you see them
+
+    Focus on:
+    - Logic errors and edge cases
+    - Security vulnerabilities (OWASP Top 10)
+    - Performance implications
+    - Code maintainability and readability
+    - Test quality and coverage
+
+  modelRef:
+    name: claude-sonnet
+
+  executionEngine:
+    name: executor-claude
+
+  tools:
+    # Read-only file operations for review
+    - type: built-in
+      name: read
+      description: Read file contents
+    - type: built-in
+      name: glob
+      description: Find files by pattern
+    - type: built-in
+      name: grep
+      description: Search file contents

--- a/services/executor-claude-agent/examples/query-example.yaml
+++ b/services/executor-claude-agent/examples/query-example.yaml
@@ -1,0 +1,45 @@
+---
+# Example Query to the developer agent
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: implement-feature
+spec:
+  type: user
+  input: |
+    Create a Python function that validates email addresses.
+    The function should:
+    - Accept a string input
+    - Return True if valid, False otherwise
+    - Handle edge cases properly
+    - Include comprehensive tests
+
+  targets:
+    - type: agent
+      name: developer
+
+  timeout: 5m
+  ttl: 1h
+---
+# Example Query to the team
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Query
+metadata:
+  name: team-feature-request
+spec:
+  type: user
+  input: |
+    Add a new REST API endpoint for user authentication.
+    Requirements:
+    - POST /api/auth/login
+    - Accept email and password
+    - Return JWT token on success
+    - Proper error handling
+    - Rate limiting
+
+  targets:
+    - type: team
+      name: sdlc-team
+
+  timeout: 15m
+  ttl: 2h

--- a/services/executor-claude-agent/examples/team-sdlc.yaml
+++ b/services/executor-claude-agent/examples/team-sdlc.yaml
@@ -1,0 +1,34 @@
+---
+# SDLC Team: Multi-agent workflow for software development
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Team
+metadata:
+  name: sdlc-team
+spec:
+  description: |
+    Software Development Lifecycle team with specialized agents
+    for development, testing, and code review.
+
+  # Agents in this team
+  agents:
+    - name: developer
+    - name: reviewer
+
+  # Orchestration: sequential workflow
+  orchestration:
+    type: sequential
+    steps:
+      - agent: developer
+        description: Implement the requested feature or fix
+      - agent: reviewer
+        description: Review the implementation for quality and security
+
+  # Shared context for the team
+  prompt: |
+    This is the SDLC team. Work together to deliver high-quality software:
+
+    1. Developer implements the requested changes
+    2. Reviewer analyzes the implementation
+    3. Developer addresses any feedback
+
+    Ensure all work follows project conventions and passes tests.

--- a/services/executor-claude-agent/requirements.txt
+++ b/services/executor-claude-agent/requirements.txt
@@ -1,0 +1,27 @@
+# ARK SDK for executor framework
+ark-sdk @ https://github.com/mckinsey/agents-at-scale-ark/releases/download/v0.1.31/ark_sdk-0.1.31-py3-none-any.whl
+
+# Claude Agent SDK for agentic execution
+claude-agent-sdk>=0.1.19
+
+# Anthropic SDK for direct API access
+anthropic>=0.40.0
+
+# AWS Bedrock support
+boto3>=1.34.0
+
+# FastAPI and dependencies (included in ark-sdk but explicit for clarity)
+fastapi>=0.115.0
+uvicorn>=0.32.0
+
+# Pydantic for data validation
+pydantic>=2.0
+
+# Environment configuration
+python-dotenv>=1.0.0
+
+# OpenTelemetry for observability
+opentelemetry-api>=1.20.0
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-grpc>=1.20.0
+opentelemetry-instrumentation-fastapi>=0.46b0

--- a/services/executor-claude-agent/src/claude_executor/__init__.py
+++ b/services/executor-claude-agent/src/claude_executor/__init__.py
@@ -1,0 +1,10 @@
+"""Claude Agent SDK Executor for ARK.
+
+Native ARK execution engine using Claude Agent SDK for agentic task execution.
+"""
+
+__version__ = "0.1.0"
+
+from .executor import ClaudeAgentExecutor
+
+__all__ = ["ClaudeAgentExecutor"]

--- a/services/executor-claude-agent/src/claude_executor/app.py
+++ b/services/executor-claude-agent/src/claude_executor/app.py
@@ -5,12 +5,13 @@ Exposes the /execute endpoint required by ARK's ExecutionEngine interface.
 
 import os
 import logging
-from typing import Any
+from typing import Annotated, Any
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from typing_extensions import Doc
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -35,66 +36,66 @@ logger = logging.getLogger(__name__)
 
 class ExecutionEngineModel(BaseModel):
     """Model configuration from ARK."""
-    name: str = "claude-sonnet-4-20250514"
-    type: str | None = "anthropic"
-    config: dict[str, Any] | None = None
+    name: Annotated[str, Doc("Claude model identifier")] = "claude-sonnet-4-20250514"
+    type: Annotated[str | None, Doc("Provider type: anthropic or bedrock")] = "anthropic"
+    config: Annotated[dict[str, Any] | None, Doc("Additional model configuration")] = None
 
 
 class AgentConfig(BaseModel):
     """Agent configuration from ARK."""
-    name: str
-    namespace: str = "default"
-    prompt: str | None = ""
-    description: str | None = ""
-    parameters: list[dict[str, Any]] | None = None
-    model: ExecutionEngineModel | None = None
-    outputSchema: dict[str, Any] | None = None
+    name: Annotated[str, Doc("Unique agent identifier")]
+    namespace: Annotated[str, Doc("Kubernetes namespace")] = "default"
+    prompt: Annotated[str | None, Doc("System prompt for the agent")] = ""
+    description: Annotated[str | None, Doc("Human-readable agent description")] = ""
+    parameters: Annotated[list[dict[str, Any]] | None, Doc("Agent parameters")] = None
+    model: Annotated[ExecutionEngineModel | None, Doc("Model configuration")] = None
+    outputSchema: Annotated[dict[str, Any] | None, Doc("JSON schema for structured output")] = None
 
 
 class MessageInput(BaseModel):
     """Message format from ARK."""
-    role: str
-    content: str
-    name: str | None = None
-    tool_calls: list[dict[str, Any]] | None = None
-    tool_call_id: str | None = None
+    role: Annotated[str, Doc("Message role: user, assistant, or system")]
+    content: Annotated[str, Doc("Message content")]
+    name: Annotated[str | None, Doc("Optional sender name")] = None
+    tool_calls: Annotated[list[dict[str, Any]] | None, Doc("Tool calls made by assistant")] = None
+    tool_call_id: Annotated[str | None, Doc("ID of tool call this message responds to")] = None
 
 
 class ToolDefinition(BaseModel):
     """Tool definition from ARK."""
-    name: str
-    description: str | None = None
-    parameters: dict[str, Any] | None = None
+    name: Annotated[str, Doc("Tool name")]
+    description: Annotated[str | None, Doc("Tool description")] = None
+    parameters: Annotated[dict[str, Any] | None, Doc("JSON schema for tool parameters")] = None
 
 
 class ExecutionEngineRequest(BaseModel):
     """Request format for ARK ExecutionEngine."""
-    agent: AgentConfig
-    userInput: MessageInput
-    history: list[MessageInput] = []
-    tools: list[ToolDefinition] = []
+    agent: Annotated[AgentConfig, Doc("Agent configuration")]
+    userInput: Annotated[MessageInput, Doc("Current user message")]
+    history: Annotated[list[MessageInput], Doc("Conversation history")] = []
+    tools: Annotated[list[ToolDefinition], Doc("Available tools")] = []
 
 
 class MessageOutput(BaseModel):
     """Message output format for ARK."""
-    role: str
-    content: str
-    name: str | None = None
-    tool_calls: list[dict[str, Any]] | None = None
-    tool_call_id: str | None = None
+    role: Annotated[str, Doc("Message role")]
+    content: Annotated[str, Doc("Message content")]
+    name: Annotated[str | None, Doc("Agent name")] = None
+    tool_calls: Annotated[list[dict[str, Any]] | None, Doc("Tool calls")] = None
+    tool_call_id: Annotated[str | None, Doc("Tool call ID")] = None
 
 
 class TokenUsage(BaseModel):
     """Token usage metrics."""
-    inputTokens: int = 0
-    outputTokens: int = 0
+    inputTokens: Annotated[int, Doc("Input tokens consumed")] = 0
+    outputTokens: Annotated[int, Doc("Output tokens generated")] = 0
 
 
 class ExecutionEngineResponse(BaseModel):
     """Response format for ARK ExecutionEngine."""
-    messages: list[MessageOutput]
-    error: str | None = None
-    tokenUsage: TokenUsage | None = None
+    messages: Annotated[list[MessageOutput], Doc("Response messages")]
+    error: Annotated[str | None, Doc("Error message if execution failed")] = None
+    tokenUsage: Annotated[TokenUsage | None, Doc("Token usage statistics")] = None
 
 
 # ============================================================================

--- a/services/executor-claude-agent/src/claude_executor/app.py
+++ b/services/executor-claude-agent/src/claude_executor/app.py
@@ -5,7 +5,7 @@ Exposes the /execute endpoint required by ARK's ExecutionEngine interface.
 
 import os
 import logging
-from typing import Dict, Any, List, Optional
+from typing import Annotated, Any
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
@@ -35,53 +35,53 @@ logger = logging.getLogger(__name__)
 
 class ExecutionEngineModel(BaseModel):
     """Model configuration from ARK."""
-    name: str = Field(default="claude-sonnet-4-20250514")
-    type: Optional[str] = Field(default="anthropic")
-    config: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    name: Annotated[str, Field(default="claude-sonnet-4-20250514")]
+    type: Annotated[str | None, Field(default="anthropic")]
+    config: Annotated[dict[str, Any] | None, Field(default_factory=dict)]
 
 
 class AgentConfig(BaseModel):
     """Agent configuration from ARK."""
     name: str
-    namespace: str = Field(default="default")
-    prompt: Optional[str] = Field(default="")
-    description: Optional[str] = Field(default="")
-    parameters: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
-    model: Optional[ExecutionEngineModel] = Field(default=None)
-    outputSchema: Optional[Dict[str, Any]] = Field(default=None)
+    namespace: Annotated[str, Field(default="default")]
+    prompt: Annotated[str | None, Field(default="")]
+    description: Annotated[str | None, Field(default="")]
+    parameters: Annotated[list[dict[str, Any]] | None, Field(default_factory=list)]
+    model: ExecutionEngineModel | None = None
+    outputSchema: dict[str, Any] | None = None
 
 
 class MessageInput(BaseModel):
     """Message format from ARK."""
     role: str
     content: str
-    name: Optional[str] = None
-    tool_calls: Optional[List[Dict[str, Any]]] = None
-    tool_call_id: Optional[str] = None
+    name: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+    tool_call_id: str | None = None
 
 
 class ToolDefinition(BaseModel):
     """Tool definition from ARK."""
     name: str
-    description: Optional[str] = None
-    parameters: Optional[Dict[str, Any]] = None
+    description: str | None = None
+    parameters: dict[str, Any] | None = None
 
 
 class ExecutionEngineRequest(BaseModel):
     """Request format for ARK ExecutionEngine."""
     agent: AgentConfig
     userInput: MessageInput
-    history: List[MessageInput] = Field(default_factory=list)
-    tools: List[ToolDefinition] = Field(default_factory=list)
+    history: Annotated[list[MessageInput], Field(default_factory=list)]
+    tools: Annotated[list[ToolDefinition], Field(default_factory=list)]
 
 
 class MessageOutput(BaseModel):
     """Message output format for ARK."""
     role: str
     content: str
-    name: Optional[str] = None
-    tool_calls: Optional[List[Dict[str, Any]]] = None
-    tool_call_id: Optional[str] = None
+    name: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+    tool_call_id: str | None = None
 
 
 class TokenUsage(BaseModel):
@@ -92,9 +92,9 @@ class TokenUsage(BaseModel):
 
 class ExecutionEngineResponse(BaseModel):
     """Response format for ARK ExecutionEngine."""
-    messages: List[MessageOutput]
-    error: Optional[str] = None
-    tokenUsage: Optional[TokenUsage] = None
+    messages: list[MessageOutput]
+    error: str | None = None
+    tokenUsage: TokenUsage | None = None
 
 
 # ============================================================================
@@ -135,7 +135,7 @@ def init_otel():
 # ============================================================================
 
 # Global executor instance
-executor: Optional[ClaudeAgentExecutor] = None
+executor: ClaudeAgentExecutor | None = None
 
 
 @asynccontextmanager

--- a/services/executor-claude-agent/src/claude_executor/app.py
+++ b/services/executor-claude-agent/src/claude_executor/app.py
@@ -5,12 +5,12 @@ Exposes the /execute endpoint required by ARK's ExecutionEngine interface.
 
 import os
 import logging
-from typing import Annotated, Any
+from typing import Any
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -35,18 +35,18 @@ logger = logging.getLogger(__name__)
 
 class ExecutionEngineModel(BaseModel):
     """Model configuration from ARK."""
-    name: Annotated[str, Field(default="claude-sonnet-4-20250514")]
-    type: Annotated[str | None, Field(default="anthropic")]
-    config: Annotated[dict[str, Any] | None, Field(default_factory=dict)]
+    name: str = "claude-sonnet-4-20250514"
+    type: str | None = "anthropic"
+    config: dict[str, Any] | None = None
 
 
 class AgentConfig(BaseModel):
     """Agent configuration from ARK."""
     name: str
-    namespace: Annotated[str, Field(default="default")]
-    prompt: Annotated[str | None, Field(default="")]
-    description: Annotated[str | None, Field(default="")]
-    parameters: Annotated[list[dict[str, Any]] | None, Field(default_factory=list)]
+    namespace: str = "default"
+    prompt: str | None = ""
+    description: str | None = ""
+    parameters: list[dict[str, Any]] | None = None
     model: ExecutionEngineModel | None = None
     outputSchema: dict[str, Any] | None = None
 
@@ -71,8 +71,8 @@ class ExecutionEngineRequest(BaseModel):
     """Request format for ARK ExecutionEngine."""
     agent: AgentConfig
     userInput: MessageInput
-    history: Annotated[list[MessageInput], Field(default_factory=list)]
-    tools: Annotated[list[ToolDefinition], Field(default_factory=list)]
+    history: list[MessageInput] = []
+    tools: list[ToolDefinition] = []
 
 
 class MessageOutput(BaseModel):

--- a/services/executor-claude-agent/src/claude_executor/app.py
+++ b/services/executor-claude-agent/src/claude_executor/app.py
@@ -1,0 +1,280 @@
+"""FastAPI application for Claude Agent SDK Executor.
+
+Exposes the /execute endpoint required by ARK's ExecutionEngine interface.
+"""
+
+import os
+import logging
+from typing import Dict, Any, List, Optional
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from .executor import ClaudeAgentExecutor, Message
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Pydantic Models for ARK ExecutionEngine Protocol
+# ============================================================================
+
+
+class ExecutionEngineModel(BaseModel):
+    """Model configuration from ARK."""
+    name: str = Field(default="claude-sonnet-4-20250514")
+    type: Optional[str] = Field(default="anthropic")
+    config: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+
+class AgentConfig(BaseModel):
+    """Agent configuration from ARK."""
+    name: str
+    namespace: str = Field(default="default")
+    prompt: Optional[str] = Field(default="")
+    description: Optional[str] = Field(default="")
+    parameters: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
+    model: Optional[ExecutionEngineModel] = Field(default=None)
+    outputSchema: Optional[Dict[str, Any]] = Field(default=None)
+
+
+class MessageInput(BaseModel):
+    """Message format from ARK."""
+    role: str
+    content: str
+    name: Optional[str] = None
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+    tool_call_id: Optional[str] = None
+
+
+class ToolDefinition(BaseModel):
+    """Tool definition from ARK."""
+    name: str
+    description: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+
+
+class ExecutionEngineRequest(BaseModel):
+    """Request format for ARK ExecutionEngine."""
+    agent: AgentConfig
+    userInput: MessageInput
+    history: List[MessageInput] = Field(default_factory=list)
+    tools: List[ToolDefinition] = Field(default_factory=list)
+
+
+class MessageOutput(BaseModel):
+    """Message output format for ARK."""
+    role: str
+    content: str
+    name: Optional[str] = None
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+    tool_call_id: Optional[str] = None
+
+
+class TokenUsage(BaseModel):
+    """Token usage metrics."""
+    inputTokens: int = 0
+    outputTokens: int = 0
+
+
+class ExecutionEngineResponse(BaseModel):
+    """Response format for ARK ExecutionEngine."""
+    messages: List[MessageOutput]
+    error: Optional[str] = None
+    tokenUsage: Optional[TokenUsage] = None
+
+
+# ============================================================================
+# OpenTelemetry Setup
+# ============================================================================
+
+
+def init_otel():
+    """Initialize OpenTelemetry if configured."""
+    otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not otel_endpoint:
+        logger.info("OTEL not configured, skipping initialization")
+        return
+
+    otel_protocol = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "executor-claude")
+
+    logger.info(f"Initializing OTEL: {otel_protocol}@{otel_endpoint}")
+
+    tracer_provider = TracerProvider(
+        resource=Resource({"service.name": service_name})
+    )
+
+    if otel_protocol == "http/protobuf":
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    else:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+    span_exporter = OTLPSpanExporter(endpoint=otel_endpoint)
+    tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    trace.set_tracer_provider(tracer_provider)
+
+    logger.info(f"OpenTelemetry initialized: {service_name}")
+
+
+# ============================================================================
+# FastAPI Application
+# ============================================================================
+
+# Global executor instance
+executor: Optional[ClaudeAgentExecutor] = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan handler."""
+    global executor
+
+    # Startup
+    logger.info("Starting Claude Agent SDK Executor...")
+    init_otel()
+    executor = ClaudeAgentExecutor()
+    logger.info("Executor initialized successfully")
+
+    yield
+
+    # Shutdown
+    logger.info("Shutting down executor...")
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(
+        title="Claude Agent SDK Executor",
+        description="ARK ExecutionEngine implementation using Claude Agent SDK",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+
+    # CORS middleware
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Instrument with OpenTelemetry
+    FastAPIInstrumentor.instrument_app(app)
+
+    @app.get("/health")
+    async def health():
+        """Health check endpoint."""
+        return {"status": "healthy", "executor": "claude"}
+
+    @app.get("/ready")
+    async def ready():
+        """Readiness check endpoint."""
+        if executor is None:
+            raise HTTPException(status_code=503, detail="Executor not initialized")
+        return {"status": "ready", "executor": "claude"}
+
+    @app.post("/execute", response_model=ExecutionEngineResponse)
+    async def execute(request: ExecutionEngineRequest) -> ExecutionEngineResponse:
+        """
+        Execute an agent request using Claude Agent SDK.
+
+        This is the main endpoint called by ARK's ExecutionEngine client.
+        """
+        if executor is None:
+            raise HTTPException(status_code=503, detail="Executor not initialized")
+
+        logger.info(
+            f"Executing agent '{request.agent.name}' with "
+            f"{len(request.tools)} tools, {len(request.history)} history messages"
+        )
+
+        try:
+            # Convert request to dict for executor
+            request_dict = {
+                "agent": request.agent.model_dump(),
+                "userInput": request.userInput.model_dump(),
+                "history": [msg.model_dump() for msg in request.history],
+                "tools": [tool.model_dump() for tool in request.tools],
+            }
+
+            # Execute with Claude Agent SDK
+            messages = await executor.execute_agent(request_dict)
+
+            # Convert Message objects to response format
+            response_messages = [
+                MessageOutput(
+                    role=msg.role,
+                    content=msg.content,
+                    name=msg.name,
+                    tool_calls=msg.tool_calls,
+                    tool_call_id=msg.tool_call_id,
+                )
+                for msg in messages
+            ]
+
+            return ExecutionEngineResponse(
+                messages=response_messages,
+                tokenUsage=TokenUsage(inputTokens=0, outputTokens=0),
+            )
+
+        except Exception as e:
+            logger.error(f"Execution failed: {e}")
+            return ExecutionEngineResponse(
+                messages=[
+                    MessageOutput(
+                        role="assistant",
+                        content=f"Execution error: {str(e)}",
+                        name=request.agent.name,
+                    )
+                ],
+                error=str(e),
+            )
+
+    @app.get("/info")
+    async def info():
+        """Get executor information."""
+        return {
+            "name": "Claude Agent SDK Executor",
+            "type": "claude",
+            "version": "0.1.0",
+            "capabilities": [
+                "agentic_execution",
+                "tool_use",
+                "multi_turn",
+                "file_operations",
+                "code_execution",
+            ],
+            "default_model": os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514"),
+            "max_turns": int(os.getenv("CLAUDE_MAX_TURNS", "10")),
+        }
+
+    return app
+
+
+# Create the app instance
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    host = os.getenv("HOST", "0.0.0.0")
+
+    logger.info(f"Starting server on {host}:{port}")
+    uvicorn.run(app, host=host, port=port)

--- a/services/executor-claude-agent/src/claude_executor/executor.py
+++ b/services/executor-claude-agent/src/claude_executor/executor.py
@@ -1,0 +1,436 @@
+"""Claude Agent SDK Executor for ARK.
+
+Implements the ARK ExecutionEngine interface using Claude Agent SDK
+for full agentic capabilities including tool use, multi-turn conversations,
+and autonomous task execution.
+"""
+
+import os
+import logging
+import asyncio
+from typing import List, Dict, Any, Optional
+
+from opentelemetry import trace
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer("executor-claude")
+
+# Configuration
+DEFAULT_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+DEFAULT_MAX_TURNS = int(os.getenv("CLAUDE_MAX_TURNS", "10"))
+
+
+class Message:
+    """ARK-compatible message format."""
+
+    def __init__(
+        self,
+        role: str,
+        content: str,
+        name: Optional[str] = None,
+        tool_calls: Optional[List[Dict]] = None,
+        tool_call_id: Optional[str] = None,
+    ):
+        self.role = role
+        self.content = content
+        self.name = name
+        self.tool_calls = tool_calls
+        self.tool_call_id = tool_call_id
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = {"role": self.role, "content": self.content}
+        if self.name:
+            result["name"] = self.name
+        if self.tool_calls:
+            result["tool_calls"] = self.tool_calls
+        if self.tool_call_id:
+            result["tool_call_id"] = self.tool_call_id
+        return result
+
+
+class ClaudeAgentExecutor:
+    """
+    ARK ExecutionEngine implementation using Claude Agent SDK.
+
+    This executor provides full agentic capabilities:
+    - Multi-turn conversations with tool use
+    - Autonomous task execution with Claude's agentic loop
+    - File operations, code execution, and search tools
+    - Integration with ARK's tool system
+    """
+
+    def __init__(self):
+        self.name = "Claude"
+        self.description = "Claude Agent SDK Executor with full agentic capabilities"
+        logger.info(f"Initialized {self.name} executor")
+
+    async def execute_agent(self, request: Dict[str, Any]) -> List[Message]:
+        """
+        Execute an agent request using Claude Agent SDK.
+
+        Args:
+            request: ExecutionEngineRequest containing:
+                - agent: AgentConfig (name, namespace, prompt, model, tools)
+                - userInput: Message with role and content
+                - history: List of previous messages
+                - tools: List of tool definitions
+
+        Returns:
+            List of Message objects with the agent's response
+        """
+        with tracer.start_as_current_span("execute_agent") as span:
+            agent_config = request.get("agent", {})
+            user_input = request.get("userInput", {})
+            history = request.get("history", [])
+            tools = request.get("tools", [])
+
+            agent_name = agent_config.get("name", "claude-agent")
+            system_prompt = agent_config.get("prompt", "")
+            model_config = agent_config.get("model") or {}
+
+            span.set_attribute("agent.name", agent_name)
+            span.set_attribute("agent.model", model_config.get("name", DEFAULT_MODEL) if model_config else DEFAULT_MODEL)
+
+            logger.info(f"Executing agent '{agent_name}' with {len(tools)} tools")
+
+            # Determine execution mode based on tools
+            if tools:
+                # Full agentic mode with Claude Agent SDK
+                return await self._execute_agentic(
+                    agent_name=agent_name,
+                    system_prompt=system_prompt,
+                    model_config=model_config,
+                    user_input=user_input,
+                    history=history,
+                    tools=tools,
+                    span=span,
+                )
+            else:
+                # Simple completion mode with Anthropic SDK
+                return await self._execute_simple(
+                    agent_name=agent_name,
+                    system_prompt=system_prompt,
+                    model_config=model_config,
+                    user_input=user_input,
+                    history=history,
+                    span=span,
+                )
+
+    async def _execute_agentic(
+        self,
+        agent_name: str,
+        system_prompt: str,
+        model_config: Dict[str, Any],
+        user_input: Dict[str, Any],
+        history: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        span,
+    ) -> List[Message]:
+        """Execute with full Claude Agent SDK agentic loop."""
+        try:
+            from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+        except ImportError:
+            logger.warning("Claude Agent SDK not available, falling back to simple mode")
+            return await self._execute_simple(
+                agent_name, system_prompt, model_config, user_input, history, span
+            )
+
+        model = model_config.get("name", DEFAULT_MODEL)
+        max_turns = model_config.get("config", {}).get("max_turns", DEFAULT_MAX_TURNS)
+
+        # Map ARK tools to Claude Agent SDK tool names
+        allowed_tools = self._map_tools_to_claude(tools)
+
+        span.set_attribute("agent.max_turns", max_turns)
+        span.set_attribute("agent.tools_count", len(allowed_tools))
+
+        # Build the task from user input
+        task = user_input.get("content", "")
+
+        # Add conversation context if there's history
+        if history:
+            context = self._format_history(history)
+            task = f"Previous conversation:\n{context}\n\nCurrent request: {task}"
+
+        options = ClaudeAgentOptions(
+            model=model,
+            max_turns=max_turns,
+            allowed_tools=allowed_tools,
+            system_prompt=system_prompt if system_prompt else None,
+        )
+
+        result_messages = []
+        final_content = ""
+
+        try:
+            async with ClaudeSDKClient(options=options) as client:
+                await client.query(task)
+                span.add_event("query_sent")
+
+                async for message in client.receive_response():
+                    if hasattr(message, 'type'):
+                        if message.type == "text":
+                            final_content = message.text
+                        elif message.type == "tool_use":
+                            span.add_event("tool_call", {"tool": message.name})
+                        elif message.type == "result":
+                            final_content = message.text if hasattr(message, 'text') else str(message)
+
+            span.set_attribute("agent.status", "success")
+
+            return [Message(
+                role="assistant",
+                content=final_content or "Task completed.",
+                name=agent_name,
+            )]
+
+        except Exception as e:
+            logger.error(f"Claude Agent SDK execution failed: {e}")
+            span.set_attribute("agent.status", "error")
+            span.record_exception(e)
+
+            # Fall back to simple mode
+            return await self._execute_simple(
+                agent_name, system_prompt, model_config, user_input, history, span
+            )
+
+    def _get_provider(self, model_config: Dict[str, Any]) -> str:
+        """Determine the provider from model config or environment."""
+        # Check model config first
+        provider = model_config.get("type", "").lower()
+        if provider in ["bedrock", "aws", "amazon"]:
+            return "bedrock"
+        if provider in ["anthropic", "claude"]:
+            return "anthropic"
+
+        # Check environment variable
+        provider_env = os.getenv("CLAUDE_PROVIDER", "").lower()
+        if provider_env in ["bedrock", "aws"]:
+            return "bedrock"
+
+        # Auto-detect based on available credentials
+        if os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION"):
+            # AWS environment detected, prefer Bedrock
+            if not os.getenv("ANTHROPIC_API_KEY"):
+                return "bedrock"
+
+        return "anthropic"
+
+    def _get_bedrock_model_id(self, model: str) -> str:
+        """Convert model name to Bedrock model ID (using cross-region inference)."""
+        # Cross-region inference profile ARNs for us-east-1
+        bedrock_models = {
+            "claude-sonnet-4-20250514": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "claude-3-5-sonnet": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "claude-3-5-sonnet-v2": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "claude-3-sonnet": "us.anthropic.claude-3-sonnet-20240229-v1:0",
+            "claude-3-haiku": "us.anthropic.claude-3-haiku-20240307-v1:0",
+            "claude-3-opus": "us.anthropic.claude-3-opus-20240229-v1:0",
+        }
+        # If already a Bedrock model ID, return as-is
+        if model.startswith("anthropic.") or model.startswith("us."):
+            return model
+        # Look up mapping
+        return bedrock_models.get(model, f"us.anthropic.{model}-v1:0")
+
+    async def _execute_simple(
+        self,
+        agent_name: str,
+        system_prompt: str,
+        model_config: Dict[str, Any],
+        user_input: Dict[str, Any],
+        history: List[Dict[str, Any]],
+        span,
+    ) -> List[Message]:
+        """Execute with Anthropic API or Bedrock (no agentic loop)."""
+        model = model_config.get("name", DEFAULT_MODEL)
+        provider = self._get_provider(model_config)
+
+        # Build messages
+        messages = []
+        for msg in history:
+            role = msg.get("role", "user")
+            if role in ["system"]:
+                continue
+            anthropic_role = "assistant" if role == "assistant" else "user"
+            messages.append({
+                "role": anthropic_role,
+                "content": msg.get("content", ""),
+            })
+
+        messages.append({
+            "role": "user",
+            "content": user_input.get("content", ""),
+        })
+
+        span.set_attribute("agent.provider", provider)
+
+        if provider == "bedrock":
+            return await self._execute_bedrock(
+                agent_name, system_prompt, model, messages, span
+            )
+        else:
+            return await self._execute_anthropic(
+                agent_name, system_prompt, model, messages, span
+            )
+
+    async def _execute_bedrock(
+        self,
+        agent_name: str,
+        system_prompt: str,
+        model: str,
+        messages: List[Dict[str, Any]],
+        span,
+    ) -> List[Message]:
+        """Execute using AWS Bedrock."""
+        try:
+            import boto3
+            import json
+        except ImportError:
+            logger.error("boto3 not installed")
+            return [Message(
+                role="assistant",
+                content="Error: boto3 not available for Bedrock",
+                name=agent_name,
+            )]
+
+        model_id = self._get_bedrock_model_id(model)
+        span.add_event("calling_bedrock_api", {"model_id": model_id})
+        logger.info(f"Calling Bedrock with model: {model_id}")
+
+        try:
+            region = os.getenv("AWS_REGION", "us-east-1")
+            bedrock = boto3.client("bedrock-runtime", region_name=region)
+
+            # Build Bedrock request body
+            body = {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 4096,
+                "system": system_prompt or "You are a helpful assistant.",
+                "messages": messages,
+            }
+
+            response = bedrock.invoke_model(
+                modelId=model_id,
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(body),
+            )
+
+            response_body = json.loads(response["body"].read())
+            content = response_body.get("content", [{}])[0].get("text", "")
+
+            span.set_attribute("agent.status", "success")
+            usage = response_body.get("usage", {})
+            span.set_attribute("agent.tokens.input", usage.get("input_tokens", 0))
+            span.set_attribute("agent.tokens.output", usage.get("output_tokens", 0))
+
+            return [Message(
+                role="assistant",
+                content=content,
+                name=agent_name,
+            )]
+
+        except Exception as e:
+            logger.error(f"Bedrock API call failed: {e}")
+            span.set_attribute("agent.status", "error")
+            span.record_exception(e)
+
+            return [Message(
+                role="assistant",
+                content=f"Error executing agent via Bedrock: {str(e)}",
+                name=agent_name,
+            )]
+
+    async def _execute_anthropic(
+        self,
+        agent_name: str,
+        system_prompt: str,
+        model: str,
+        messages: List[Dict[str, Any]],
+        span,
+    ) -> List[Message]:
+        """Execute using direct Anthropic API."""
+        try:
+            import anthropic
+        except ImportError:
+            logger.error("Anthropic SDK not installed")
+            return [Message(
+                role="assistant",
+                content="Error: Anthropic SDK not available",
+                name=agent_name,
+            )]
+
+        span.add_event("calling_anthropic_api")
+
+        try:
+            client = anthropic.Anthropic()
+
+            response = client.messages.create(
+                model=model,
+                max_tokens=4096,
+                system=system_prompt or "You are a helpful assistant.",
+                messages=messages,
+            )
+
+            content = response.content[0].text if response.content else ""
+
+            span.set_attribute("agent.status", "success")
+            span.set_attribute("agent.tokens.input", response.usage.input_tokens)
+            span.set_attribute("agent.tokens.output", response.usage.output_tokens)
+
+            return [Message(
+                role="assistant",
+                content=content,
+                name=agent_name,
+            )]
+
+        except Exception as e:
+            logger.error(f"Anthropic API call failed: {e}")
+            span.set_attribute("agent.status", "error")
+            span.record_exception(e)
+
+            return [Message(
+                role="assistant",
+                content=f"Error executing agent: {str(e)}",
+                name=agent_name,
+            )]
+
+    def _map_tools_to_claude(self, ark_tools: List[Dict[str, Any]]) -> List[str]:
+        """Map ARK tool definitions to Claude Agent SDK tool names."""
+        # Claude Agent SDK built-in tools
+        claude_tools = {
+            "read": "Read",
+            "write": "Write",
+            "edit": "Edit",
+            "bash": "Bash",
+            "glob": "Glob",
+            "grep": "Grep",
+            "web_fetch": "WebFetch",
+            "web_search": "WebSearch",
+        }
+
+        allowed = []
+        for tool in ark_tools:
+            tool_name = tool.get("name", "").lower().replace("-", "_").replace(" ", "_")
+
+            # Check if it maps to a Claude Agent SDK built-in tool
+            if tool_name in claude_tools:
+                allowed.append(claude_tools[tool_name])
+            elif tool_name in ["read", "write", "edit", "bash", "glob", "grep"]:
+                allowed.append(tool_name.capitalize())
+
+        # Default tools if none mapped
+        if not allowed:
+            allowed = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+
+        return allowed
+
+    def _format_history(self, history: List[Dict[str, Any]]) -> str:
+        """Format conversation history as context string."""
+        lines = []
+        for msg in history:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            lines.append(f"{role.upper()}: {content}")
+        return "\n".join(lines)

--- a/services/executor-claude-agent/src/claude_executor/executor.py
+++ b/services/executor-claude-agent/src/claude_executor/executor.py
@@ -7,9 +7,11 @@ and autonomous task execution.
 
 import os
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from opentelemetry import trace
+from pydantic import BaseModel
+from typing_extensions import Doc
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer("executor-claude")
@@ -19,32 +21,13 @@ DEFAULT_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
 DEFAULT_MAX_TURNS = int(os.getenv("CLAUDE_MAX_TURNS", "10"))
 
 
-class Message:
+class Message(BaseModel):
     """ARK-compatible message format."""
-
-    def __init__(
-        self,
-        role: str,
-        content: str,
-        name: str | None = None,
-        tool_calls: list[dict] | None = None,
-        tool_call_id: str | None = None,
-    ):
-        self.role = role
-        self.content = content
-        self.name = name
-        self.tool_calls = tool_calls
-        self.tool_call_id = tool_call_id
-
-    def to_dict(self) -> dict[str, Any]:
-        result = {"role": self.role, "content": self.content}
-        if self.name:
-            result["name"] = self.name
-        if self.tool_calls:
-            result["tool_calls"] = self.tool_calls
-        if self.tool_call_id:
-            result["tool_call_id"] = self.tool_call_id
-        return result
+    role: Annotated[str, Doc("Message role")]
+    content: Annotated[str, Doc("Message content")]
+    name: Annotated[str | None, Doc("Sender name")] = None
+    tool_calls: Annotated[list[dict] | None, Doc("Tool calls")] = None
+    tool_call_id: Annotated[str | None, Doc("Tool call ID")] = None
 
 
 class ClaudeAgentExecutor:

--- a/services/executor-claude-agent/src/claude_executor/executor.py
+++ b/services/executor-claude-agent/src/claude_executor/executor.py
@@ -7,8 +7,7 @@ and autonomous task execution.
 
 import os
 import logging
-import asyncio
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 from opentelemetry import trace
 
@@ -27,9 +26,9 @@ class Message:
         self,
         role: str,
         content: str,
-        name: Optional[str] = None,
-        tool_calls: Optional[List[Dict]] = None,
-        tool_call_id: Optional[str] = None,
+        name: str | None = None,
+        tool_calls: list[dict] | None = None,
+        tool_call_id: str | None = None,
     ):
         self.role = role
         self.content = content
@@ -37,7 +36,7 @@ class Message:
         self.tool_calls = tool_calls
         self.tool_call_id = tool_call_id
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {"role": self.role, "content": self.content}
         if self.name:
             result["name"] = self.name
@@ -64,7 +63,7 @@ class ClaudeAgentExecutor:
         self.description = "Claude Agent SDK Executor with full agentic capabilities"
         logger.info(f"Initialized {self.name} executor")
 
-    async def execute_agent(self, request: Dict[str, Any]) -> List[Message]:
+    async def execute_agent(self, request: dict[str, Any]) -> list[Message]:
         """
         Execute an agent request using Claude Agent SDK.
 
@@ -120,12 +119,12 @@ class ClaudeAgentExecutor:
         self,
         agent_name: str,
         system_prompt: str,
-        model_config: Dict[str, Any],
-        user_input: Dict[str, Any],
-        history: List[Dict[str, Any]],
-        tools: List[Dict[str, Any]],
+        model_config: dict[str, Any],
+        user_input: dict[str, Any],
+        history: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
         span,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """Execute with full Claude Agent SDK agentic loop."""
         try:
             from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
@@ -194,7 +193,7 @@ class ClaudeAgentExecutor:
                 agent_name, system_prompt, model_config, user_input, history, span
             )
 
-    def _get_provider(self, model_config: Dict[str, Any]) -> str:
+    def _get_provider(self, model_config: dict[str, Any]) -> str:
         """Determine the provider from model config or environment."""
         # Check model config first
         provider = model_config.get("type", "").lower()
@@ -237,11 +236,11 @@ class ClaudeAgentExecutor:
         self,
         agent_name: str,
         system_prompt: str,
-        model_config: Dict[str, Any],
-        user_input: Dict[str, Any],
-        history: List[Dict[str, Any]],
+        model_config: dict[str, Any],
+        user_input: dict[str, Any],
+        history: list[dict[str, Any]],
         span,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """Execute with Anthropic API or Bedrock (no agentic loop)."""
         model = model_config.get("name", DEFAULT_MODEL)
         provider = self._get_provider(model_config)
@@ -279,9 +278,9 @@ class ClaudeAgentExecutor:
         agent_name: str,
         system_prompt: str,
         model: str,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         span,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """Execute using AWS Bedrock."""
         try:
             import boto3
@@ -347,9 +346,9 @@ class ClaudeAgentExecutor:
         agent_name: str,
         system_prompt: str,
         model: str,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         span,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """Execute using direct Anthropic API."""
         try:
             import anthropic
@@ -396,7 +395,7 @@ class ClaudeAgentExecutor:
                 name=agent_name,
             )]
 
-    def _map_tools_to_claude(self, ark_tools: List[Dict[str, Any]]) -> List[str]:
+    def _map_tools_to_claude(self, ark_tools: list[dict[str, Any]]) -> list[str]:
         """Map ARK tool definitions to Claude Agent SDK tool names."""
         # Claude Agent SDK built-in tools
         claude_tools = {
@@ -426,7 +425,7 @@ class ClaudeAgentExecutor:
 
         return allowed
 
-    def _format_history(self, history: List[Dict[str, Any]]) -> str:
+    def _format_history(self, history: list[dict[str, Any]]) -> str:
         """Format conversation history as context string."""
         lines = []
         for msg in history:


### PR DESCRIPTION
Adds a new ARK ExecutionEngine that enables Claude models via Anthropic API or AWS Bedrock. This allows creating ARK agents powered by Claude for code generation, analysis, and multi-turn conversations.