### PR TITLE
fix: marketplace installation detection

### DIFF
--- a/.github/workflows/_reusable-charts-cicd.yaml
+++ b/.github/workflows/_reusable-charts-cicd.yaml
@@ -99,49 +99,6 @@ jobs:
           kubectl get svc -n ${{ inputs.chart-namespace }}
           kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=${{ inputs.chart-name }}-test -n ${{ inputs.chart-namespace }} --timeout=300s
 
-      - name: Verify Marketplace Label on Deployment
-        run: |
-          echo "Verifying marketplace label is applied to deployment..."
-
-          # Check if deployment has the marketplace label
-          DEPLOYMENTS=$(kubectl get deployments -n ${{ inputs.chart-namespace }} -l ark.mckinsey.com/marketplace-item=${{ inputs.chart-name }} -o name)
-
-          if [ -z "$DEPLOYMENTS" ]; then
-            echo "ERROR: No deployments found with label ark.mckinsey.com/marketplace-item=${{ inputs.chart-name }}"
-            echo ""
-            echo "Current deployments in namespace:"
-            kubectl get deployments -n ${{ inputs.chart-namespace }} -o custom-columns=NAME:.metadata.name,LABELS:.metadata.labels
-            echo ""
-            echo "The marketplace label is required for installation status detection in the ARK dashboard."
-            echo ""
-            echo "To fix this, you have two options:"
-            echo ""
-            echo "1. Use the ark-marketplace-common library chart (recommended for external OCI charts):"
-            echo "   See: charts/ark-marketplace-common/README.md"
-            echo ""
-            echo "2. Add labels directly to your deployment templates:"
-            echo "   In templates/_helpers.tpl, ensure your labels include:"
-            echo "   {{- with .Values.global.labels }}"
-            echo "   {{ toYaml . }}"
-            echo "   {{- end }}"
-            echo ""
-            exit 1
-          else
-            echo "✓ Marketplace label successfully applied to deployment(s):"
-            echo "$DEPLOYMENTS"
-
-            # Verify label value matches chart name
-            for deployment in $DEPLOYMENTS; do
-              LABEL_VALUE=$(kubectl get "$deployment" -n ${{ inputs.chart-namespace }} -o jsonpath='{.metadata.labels.ark\.mckinsey\.com/marketplace-item}')
-              if [ "$LABEL_VALUE" != "${{ inputs.chart-name }}" ]; then
-                echo "ERROR: Label value '$LABEL_VALUE' does not match expected chart name '${{ inputs.chart-name }}'"
-                echo "The label value must match the 'name' field in marketplace.json"
-                exit 1
-              fi
-            done
-            echo "✓ Label value verification passed"
-          fi
-
       - name: Cleanup
         if: always()
         run: |
@@ -196,40 +153,6 @@ jobs:
       - name: Lint Helm Chart - ${{ inputs.chart-name }}
         run: |
           helm lint chart/
-
-      - name: Validate Marketplace Label - ${{ inputs.chart-name }}
-        run: |
-          echo "Validating marketplace label in values.yaml..."
-
-          # Check if values.yaml exists
-          if [ ! -f chart/values.yaml ]; then
-            echo "ERROR: chart/values.yaml not found"
-            exit 1
-          fi
-
-          # Check if marketplace label exists in global.labels
-          if ! yq eval '.global.labels."ark.mckinsey.com/marketplace-item"' chart/values.yaml | grep -q .; then
-            echo "ERROR: Missing required marketplace label in chart/values.yaml"
-            echo "Please add the following to your values.yaml:"
-            echo ""
-            echo "global:"
-            echo "  labels:"
-            echo "    ark.mckinsey.com/marketplace-item: \"${{ inputs.chart-name }}\""
-            echo ""
-            exit 1
-          fi
-
-          # Get the label value
-          LABEL_VALUE=$(yq eval '.global.labels."ark.mckinsey.com/marketplace-item"' chart/values.yaml)
-
-          # Check if label value matches chart name
-          if [ "$LABEL_VALUE" != "${{ inputs.chart-name }}" ]; then
-            echo "WARNING: Marketplace label value '$LABEL_VALUE' does not match chart name '${{ inputs.chart-name }}'"
-            echo "This may cause installation detection issues in the ARK dashboard."
-            echo "Label value should match the 'name' field in marketplace.json"
-          else
-            echo "✓ Marketplace label validation passed: $LABEL_VALUE"
-          fi
 
       - name: Package Helm Chart - ${{ inputs.chart-name }}
         run: |

--- a/.github/workflows/_reusable-charts-cicd.yaml
+++ b/.github/workflows/_reusable-charts-cicd.yaml
@@ -99,6 +99,49 @@ jobs:
           kubectl get svc -n ${{ inputs.chart-namespace }}
           kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=${{ inputs.chart-name }}-test -n ${{ inputs.chart-namespace }} --timeout=300s
 
+      - name: Verify Marketplace Label on Deployment
+        run: |
+          echo "Verifying marketplace label is applied to deployment..."
+
+          # Check if deployment has the marketplace label
+          DEPLOYMENTS=$(kubectl get deployments -n ${{ inputs.chart-namespace }} -l ark.mckinsey.com/marketplace-item=${{ inputs.chart-name }} -o name)
+
+          if [ -z "$DEPLOYMENTS" ]; then
+            echo "ERROR: No deployments found with label ark.mckinsey.com/marketplace-item=${{ inputs.chart-name }}"
+            echo ""
+            echo "Current deployments in namespace:"
+            kubectl get deployments -n ${{ inputs.chart-namespace }} -o custom-columns=NAME:.metadata.name,LABELS:.metadata.labels
+            echo ""
+            echo "The marketplace label is required for installation status detection in the ARK dashboard."
+            echo ""
+            echo "To fix this, you have two options:"
+            echo ""
+            echo "1. Use the ark-marketplace-common library chart (recommended for external OCI charts):"
+            echo "   See: charts/ark-marketplace-common/README.md"
+            echo ""
+            echo "2. Add labels directly to your deployment templates:"
+            echo "   In templates/_helpers.tpl, ensure your labels include:"
+            echo "   {{- with .Values.global.labels }}"
+            echo "   {{ toYaml . }}"
+            echo "   {{- end }}"
+            echo ""
+            exit 1
+          else
+            echo "✓ Marketplace label successfully applied to deployment(s):"
+            echo "$DEPLOYMENTS"
+
+            # Verify label value matches chart name
+            for deployment in $DEPLOYMENTS; do
+              LABEL_VALUE=$(kubectl get "$deployment" -n ${{ inputs.chart-namespace }} -o jsonpath='{.metadata.labels.ark\.mckinsey\.com/marketplace-item}')
+              if [ "$LABEL_VALUE" != "${{ inputs.chart-name }}" ]; then
+                echo "ERROR: Label value '$LABEL_VALUE' does not match expected chart name '${{ inputs.chart-name }}'"
+                echo "The label value must match the 'name' field in marketplace.json"
+                exit 1
+              fi
+            done
+            echo "✓ Label value verification passed"
+          fi
+
       - name: Cleanup
         if: always()
         run: |
@@ -153,6 +196,40 @@ jobs:
       - name: Lint Helm Chart - ${{ inputs.chart-name }}
         run: |
           helm lint chart/
+
+      - name: Validate Marketplace Label - ${{ inputs.chart-name }}
+        run: |
+          echo "Validating marketplace label in values.yaml..."
+
+          # Check if values.yaml exists
+          if [ ! -f chart/values.yaml ]; then
+            echo "ERROR: chart/values.yaml not found"
+            exit 1
+          fi
+
+          # Check if marketplace label exists in global.labels
+          if ! yq eval '.global.labels."ark.mckinsey.com/marketplace-item"' chart/values.yaml | grep -q .; then
+            echo "ERROR: Missing required marketplace label in chart/values.yaml"
+            echo "Please add the following to your values.yaml:"
+            echo ""
+            echo "global:"
+            echo "  labels:"
+            echo "    ark.mckinsey.com/marketplace-item: \"${{ inputs.chart-name }}\""
+            echo ""
+            exit 1
+          fi
+
+          # Get the label value
+          LABEL_VALUE=$(yq eval '.global.labels."ark.mckinsey.com/marketplace-item"' chart/values.yaml)
+
+          # Check if label value matches chart name
+          if [ "$LABEL_VALUE" != "${{ inputs.chart-name }}" ]; then
+            echo "WARNING: Marketplace label value '$LABEL_VALUE' does not match chart name '${{ inputs.chart-name }}'"
+            echo "This may cause installation detection issues in the ARK dashboard."
+            echo "Label value should match the 'name' field in marketplace.json"
+          else
+            echo "✓ Marketplace label validation passed: $LABEL_VALUE"
+          fi
 
       - name: Package Helm Chart - ${{ inputs.chart-name }}
         run: |

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -43,6 +43,8 @@ jobs:
     strategy:
       matrix:
         chart:
+          # library chart for marketplace label patching (must be first for dependencies)
+          - { name: ark-marketplace-common, path: charts/ark-marketplace-common, namespace: default, run-deployment-test: false }
           # disable langfuse deployment tests for PRs to avoid hitting 5m limit
           - { name: langfuse, path: services/langfuse, namespace: langfuse, run-deployment-test: false }
           # disable phoenix deployment tests for PRs to avoid hitting 5m limit
@@ -172,6 +174,7 @@ jobs:
     strategy:
       matrix:
         chart:
+          - { name: ark-marketplace-common, path: charts/ark-marketplace-common, namespace: default }
           - { name: langfuse, path: services/langfuse, namespace: langfuse }
           - { name: phoenix, path: services/phoenix, namespace: phoenix }
           - { name: a2a-inspector, path: services/a2a-inspector, namespace: default }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,17 +80,98 @@ Each marketplace item should include:
    - Usage examples
    - Troubleshooting
 
-3. **Helm Chart** (for services): 
+3. **Helm Chart** (for services):
    - Place in `chart/` subdirectory
    - Include `Chart.yaml` with proper metadata
    - Provide `values.yaml` with sensible defaults
    - Include necessary templates
+   - **REQUIRED**: Add marketplace identification label
+
+   **For charts with custom templates (you control the templates):**
+
+   Add the label to `values.yaml`:
+   ```yaml
+   global:
+     labels:
+       ark.mckinsey.com/marketplace-item: "your-service-name"
+   ```
+
+   Apply labels in `templates/_helpers.tpl`:
+   ```yaml
+   {{- with .Values.global.labels }}
+   {{ toYaml . }}
+   {{- end }}
+   ```
+
+   **For external OCI charts (wrapper charts):**
+
+   If your service wraps an external OCI chart that doesn't support custom labels, use the **ark-marketplace-common library chart**:
+
+   1. Add library dependency in `Chart.yaml`:
+      ```yaml
+      dependencies:
+        - name: ark-marketplace-common
+          version: "0.1.x"
+          repository: "file://../../charts/ark-marketplace-common"
+        - name: external-chart
+          version: "1.0.0"
+          repository: "oci://registry.example.com/charts"
+      ```
+
+   2. Add label to `values.yaml`:
+      ```yaml
+      global:
+        labels:
+          ark.mckinsey.com/marketplace-item: "your-service-name"
+      ```
+
+   3. Create `templates/marketplace-label-patch.yaml`:
+      ```yaml
+      {{- include "ark-marketplace.labelPatchHook" (dict "Chart" .Chart "Release" .Release "Values" .Values) }}
+      ```
+
+   4. Update dependencies:
+      ```bash
+      helm dependency update chart/
+      ```
+
+   See `services/phoenix/` for a complete example and `charts/ark-marketplace-common/README.md` for details.
+
+   **Why this is required:** The label enables installation status detection in the ARK dashboard. Without it, services will work but show as "not installed" in the UI. The label value MUST match the `name` field in `marketplace.json`.
 
 4. **DevSpace Configuration** (recommended):
    - `devspace.yaml` for local development
    - Enables hot-reload and easy testing
 
 5. **Documentation Page**: Add a corresponding page in `docs/content/` to appear in the online documentation
+
+**External OCI Chart Label Problem**
+
+When your marketplace service wraps an **external OCI chart** (a chart you don't control, like `oci://registry-1.docker.io/arizephoenix/phoenix-helm`), the external chart typically hardcodes its deployment labels and ignores your `global.labels` values. This prevents the marketplace label from being applied, causing the ARK dashboard to show the service as "not installed" even when it's running.
+
+**Solution: Use the ark-marketplace-common Library Chart**
+
+The `ark-marketplace-common` library provides a **post-install hook** that automatically patches deployments with the marketplace label after installation:
+
+1. **What it does:**
+   - Waits for external chart to create deployment
+   - Patches deployment with `ark.mckinsey.com/marketplace-item` label
+   - Handles race conditions and retries automatically
+   - Creates necessary RBAC resources
+
+2. **When to use it:**
+   - ✅ Wrapping external OCI charts
+   - ✅ External chart doesn't support custom labels
+   - ✅ Service creates Deployments
+
+3. **How to use it:**
+   - See complete instructions in `charts/ark-marketplace-common/README.md`
+   - Reference implementation: `services/phoenix/`
+
+4. **Alternatives (not recommended):**
+   - Fork the external chart and modify templates
+   - Manual `kubectl patch` after installation (not automated)
+   - Helm `--post-renderer` with kustomize (requires changing installation commands)
 
 **Testing Your Contribution**
 
@@ -99,6 +180,49 @@ Before submitting:
 - Verify all documentation is accurate
 - Ensure examples work as described
 - Check that your item integrates properly with the ARK platform
+- Verify the marketplace label is correctly applied:
+  ```bash
+  kubectl get deployment -n <namespace> -l ark.mckinsey.com/marketplace-item=<your-service-name> -o yaml
+  ```
+
+**Troubleshooting**
+
+If your item shows as "not installed" in the ARK dashboard despite being deployed:
+
+1. **Verify label exists on deployment:**
+   ```bash
+   kubectl get deployment -n <namespace> -l ark.mckinsey.com/marketplace-item=<service-name>
+   ```
+
+   If no deployment is found:
+   - For custom templates: Ensure labels are applied from `Values.global.labels` in `_helpers.tpl`
+   - For external OCI charts: Use the `ark-marketplace-common` library chart (see above)
+
+2. **Verify label value matches marketplace.json:**
+   ```bash
+   kubectl get deployment -n <namespace> <deployment-name> -o jsonpath='{.metadata.labels.ark\.mckinsey\.com/marketplace-item}'
+   ```
+
+   This must exactly match the `name` field in `marketplace.json`
+
+3. **Check post-install hook (for external OCI charts):**
+   ```bash
+   kubectl get jobs -n <namespace> | grep label-patcher
+   kubectl logs -n <namespace> job/<service-name>-label-patcher
+   ```
+
+   If the job failed, check RBAC permissions and retry the installation
+
+4. **Verify ARK API supports labelSelector** (requires ARK v0.2.0+):
+   ```bash
+   kubectl port-forward -n ark-system svc/ark-api 8080:8080
+   curl "http://localhost:8080/v1/resources/apis/apps/v1/Deployment?namespace=<namespace>&labelSelector=ark.mckinsey.com%2Fmarketplace-item%3D<service-name>"
+   ```
+
+For more details, see:
+- `charts/ark-marketplace-common/README.md` - Library chart documentation
+- `services/phoenix/` - Reference implementation
+- CI logs for validation failures
 
 **Language and Technology Choices**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,6 @@ If your item shows as "not installed" in the ARK dashboard despite being deploye
 For more details, see:
 - `charts/ark-marketplace-common/README.md` - Library chart documentation
 - `services/phoenix/` - Reference implementation
-- CI logs for validation failures
 
 **Language and Technology Choices**
 

--- a/charts/ark-marketplace-common/Chart.yaml
+++ b/charts/ark-marketplace-common/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: ark-marketplace-common
+description: Common library chart for ARK Marketplace items
+type: library
+version: 0.1.0
+keywords:
+  - ark
+  - marketplace
+  - library
+home: https://github.com/mckinsey/agents-at-scale-marketplace
+sources:
+  - https://github.com/mckinsey/agents-at-scale-marketplace
+maintainers:
+  - name: ARK Team
+    url: https://github.com/mckinsey/agents-at-scale-marketplace

--- a/charts/ark-marketplace-common/README.md
+++ b/charts/ark-marketplace-common/README.md
@@ -1,0 +1,218 @@
+# ARK Marketplace Common Library Chart
+
+Reusable Helm library chart providing common templates for ARK Marketplace items.
+
+## Purpose
+
+This library chart solves the **external OCI chart label problem**: When marketplace services use external OCI charts as dependencies (charts not maintained by us), those charts often don't support custom labels. This prevents the ARK dashboard from detecting installations.
+
+This library provides a **post-install hook** that automatically patches deployments with the required `ark.mckinsey.com/marketplace-item` label after installation.
+
+## When to Use
+
+Use this library chart if your marketplace service:
+
+✅ **Wraps an external OCI chart** (e.g., Phoenix wraps `oci://registry-1.docker.io/arizephoenix/phoenix-helm`)
+✅ **External chart ignores `global.labels`** in values.yaml
+✅ **Creates Deployments** (not just StatefulSets or DaemonSets)
+
+**Don't use** if your service:
+- Has full control over chart templates (just add labels directly to templates)
+- Only creates CRD resources (ARK detects those automatically)
+- Doesn't create any Deployments
+
+## How to Use
+
+### 1. Add Dependency
+
+Add this library chart as a dependency in your service's `Chart.yaml`:
+
+```yaml
+# services/your-service/chart/Chart.yaml
+apiVersion: v2
+name: your-service
+version: 1.0.0
+dependencies:
+  - name: ark-marketplace-common
+    version: "0.1.x"
+    repository: "file://../../charts/ark-marketplace-common"
+  - name: external-chart
+    version: "1.0.0"
+    repository: "oci://registry.example.com/charts"
+```
+
+### 2. Add Required Labels
+
+Ensure your `values.yaml` contains the marketplace label:
+
+```yaml
+# services/your-service/chart/values.yaml
+global:
+  labels:
+    ark.mckinsey.com/marketplace-item: "your-service"  # Must match marketplace.json name
+```
+
+### 3. Include Post-Install Hook
+
+Create a template file that includes the hook:
+
+```yaml
+# services/your-service/chart/templates/marketplace-label-patch.yaml
+{{- include "ark-marketplace.labelPatchHook" (dict "Chart" .Chart "Release" .Release "Values" .Values) }}
+```
+
+### 4. Update Dependencies
+
+Build the chart dependencies:
+
+```bash
+cd services/your-service/chart
+helm dependency update
+```
+
+## What It Does
+
+When you install your service, the library chart:
+
+1. **Pre-install**: Creates ServiceAccount, Role, and RoleBinding with deployment patch permissions
+2. **Post-install**: Launches a Job that:
+   - Waits for deployment(s) to be created
+   - Patches ALL deployments in the namespace with `ark.mckinsey.com/marketplace-item` label
+   - Waits for deployments to become available
+3. **Cleanup**: Automatically deletes the Job after successful completion
+
+## Complete Example
+
+See `services/phoenix/` for a complete working example.
+
+### Chart.yaml
+```yaml
+apiVersion: v2
+name: phoenix
+version: 1.0.0
+dependencies:
+  - name: ark-marketplace-common
+    version: "0.1.0"
+    repository: "file://../../charts/ark-marketplace-common"
+  - name: phoenix-helm
+    version: "4.2.0"
+    repository: "oci://registry-1.docker.io/arizephoenix"
+```
+
+### values.yaml
+```yaml
+global:
+  labels:
+    ark.mckinsey.com/marketplace-item: "phoenix"
+```
+
+### templates/marketplace-label-patch.yaml
+```yaml
+{{- include "ark-marketplace.labelPatchHook" (dict "Chart" .Chart "Release" .Release "Values" .Values) }}
+```
+
+## Testing
+
+After installation, verify the label was applied:
+
+```bash
+# Install your service
+helm upgrade --install your-service ./chart -n your-namespace
+
+# Verify label on deployment
+kubectl get deployment -n your-namespace \
+  -l ark.mckinsey.com/marketplace-item=your-service \
+  -o jsonpath='{.items[0].metadata.labels.ark\.mckinsey\.com/marketplace-item}'
+
+# Expected output: your-service
+```
+
+## How It Works
+
+### Timeline
+
+```
+t0: helm install starts
+t1: Pre-install hook creates RBAC resources (ServiceAccount, Role, RoleBinding)
+t2: External chart creates Deployment (without marketplace label)
+t3: Post-install hook Job starts
+t4: Job waits for deployment to exist
+t5: Job patches deployment with label
+t6: Job waits for deployment to be Available
+t7: Job completes, gets deleted
+```
+
+### Race Condition Handling
+
+The hook includes wait logic to handle the race condition where the deployment might not exist yet when the post-install hook runs:
+
+- **Wait for deployment creation**: Retries for up to 60 seconds
+- **Wait for deployment availability**: Uses `kubectl wait --for=condition=available`
+- **Backoff and retry**: Job has `backoffLimit: 3` for automatic retries
+
+## Troubleshooting
+
+### Label not applied after installation
+
+1. **Check if Job ran successfully**:
+   ```bash
+   kubectl get jobs -n your-namespace
+   kubectl logs -n your-namespace job/your-service-label-patcher
+   ```
+
+2. **Check RBAC permissions**:
+   ```bash
+   kubectl get role,rolebinding -n your-namespace | grep label-patcher
+   ```
+
+3. **Verify values.yaml has label**:
+   ```bash
+   yq eval '.global.labels."ark.mckinsey.com/marketplace-item"' chart/values.yaml
+   ```
+
+### Job fails with "No deployments found"
+
+This means the external chart didn't create any Deployments. Check:
+- Does the chart create StatefulSets or DaemonSets instead?
+- Is the chart configured correctly?
+- Are there any chart installation errors?
+
+### Dashboard still shows "not installed"
+
+1. **Verify label on deployment**:
+   ```bash
+   kubectl get deployment -n your-namespace -o yaml | grep ark.mckinsey.com/marketplace-item
+   ```
+
+2. **Check label value matches marketplace.json name**:
+   - Label value: `ark.mckinsey.com/marketplace-item: "phoenix"`
+   - marketplace.json: `"name": "phoenix"`
+   - These MUST match exactly
+
+3. **Verify ark-api has labelSelector support** (requires ark v0.2.0+):
+   ```bash
+   kubectl port-forward -n ark-system svc/ark-api 8080:8080
+   curl "http://localhost:8080/v1/resources/apis/apps/v1/Deployment?namespace=your-namespace&labelSelector=ark.mckinsey.com%2Fmarketplace-item%3Dyour-service"
+   ```
+
+## Alternative Solutions
+
+If you can't use this library chart, consider:
+
+1. **Fork the external chart**: Modify templates to support `global.labels`
+2. **Manual patching**: Document manual `kubectl patch` command for users
+3. **Helm post-renderer**: Use `--post-renderer` with kustomize (requires changes to installation commands)
+
+## Maintenance
+
+This library chart is maintained alongside the marketplace repo. When updating:
+
+1. Update version in `Chart.yaml`
+2. Test with all services using the library
+3. Update this README if behavior changes
+
+## References
+
+- [Helm Library Charts](https://helm.sh/docs/topics/library_charts/)
+- [Helm Hooks](https://helm.sh/docs/topics/charts_hooks/)
+- [EXTERNAL_CHART_LABEL_ISSUE.md](../../openspec/changes/2026-03-19-fix-marketplace-installation-detection/EXTERNAL_CHART_LABEL_ISSUE.md) - Detailed problem analysis

--- a/charts/ark-marketplace-common/README.md
+++ b/charts/ark-marketplace-common/README.md
@@ -215,4 +215,3 @@ This library chart is maintained alongside the marketplace repo. When updating:
 
 - [Helm Library Charts](https://helm.sh/docs/topics/library_charts/)
 - [Helm Hooks](https://helm.sh/docs/topics/charts_hooks/)
-- [EXTERNAL_CHART_LABEL_ISSUE.md](../../openspec/changes/2026-03-19-fix-marketplace-installation-detection/EXTERNAL_CHART_LABEL_ISSUE.md) - Detailed problem analysis

--- a/charts/ark-marketplace-common/templates/_marketplace-label-patch.tpl
+++ b/charts/ark-marketplace-common/templates/_marketplace-label-patch.tpl
@@ -1,0 +1,170 @@
+{{/*
+Create a post-install/post-upgrade hook Job that patches deployments with marketplace labels.
+This is needed for charts that use external OCI dependencies which don't support custom labels.
+
+Usage:
+  {{ include "ark-marketplace.labelPatchHook" (dict "Chart" .Chart "Release" .Release "Values" .Values) }}
+
+Prerequisites:
+  - values.yaml must contain:
+    global:
+      labels:
+        ark.mckinsey.com/marketplace-item: "your-service-name"
+
+  - This template creates all required resources:
+    - ServiceAccount with proper RBAC
+    - Role with deployment patch permissions
+    - RoleBinding
+    - Job that waits for deployment and applies label
+*/}}
+{{- define "ark-marketplace.labelPatchHook" -}}
+{{- $marketplaceLabel := index .Values.global.labels "ark.mckinsey.com/marketplace-item" | default .Release.Name -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-label-patcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: label-patcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-label-patcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: label-patcher
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "patch"]
+- apiGroups: ["apps"]
+  resources: ["deployments/status"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-label-patcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: label-patcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-label-patcher
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-label-patcher
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-label-patcher
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: label-patcher
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: label-patcher
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-label-patcher
+      containers:
+      - name: label-patcher
+        image: alpine/k8s:1.28.3
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "Waiting for deployment(s) in namespace {{ .Release.Namespace }} to be created..."
+
+          # Wait for at least one deployment to exist
+          RETRY_COUNT=0
+          MAX_RETRIES=30
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            DEPLOYMENT_COUNT=$(kubectl get deployments -n {{ .Release.Namespace }} -o name | wc -l)
+            if [ "$DEPLOYMENT_COUNT" -gt 0 ]; then
+              echo "Found $DEPLOYMENT_COUNT deployment(s)"
+              break
+            fi
+            echo "Waiting for deployment(s)... (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+            sleep 2
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+          done
+
+          if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+            echo "ERROR: No deployments found after waiting"
+            exit 1
+          fi
+
+          # Get all deployments in this namespace
+          DEPLOYMENTS=$(kubectl get deployments -n {{ .Release.Namespace }} -o name)
+
+          echo "Patching deployment(s) with marketplace label..."
+          echo "$DEPLOYMENTS" | while read -r deployment; do
+            echo "Patching $deployment..."
+            kubectl patch "$deployment" -n {{ .Release.Namespace }} \
+              --type=merge \
+              -p '{"metadata":{"labels":{"ark.mckinsey.com/marketplace-item":"{{ $marketplaceLabel }}"}}}'
+
+            # Wait for deployment to be available
+            DEPLOYMENT_NAME=$(echo "$deployment" | sed 's|deployment.apps/||')
+            kubectl wait --for=condition=available deployment/"$DEPLOYMENT_NAME" \
+              -n {{ .Release.Namespace }} \
+              --timeout=120s || echo "Warning: Deployment $DEPLOYMENT_NAME did not become available within timeout"
+          done
+
+          echo "Successfully patched deployment(s) with label ark.mckinsey.com/marketplace-item={{ $marketplaceLabel }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+{{- end -}}

--- a/charts/ark-marketplace-common/values.yaml
+++ b/charts/ark-marketplace-common/values.yaml
@@ -1,0 +1,11 @@
+# Default values for ark-marketplace-common library chart.
+# This is a library chart and doesn't install any resources on its own.
+# It provides reusable templates to be included in other charts.
+
+# This file is here for documentation purposes only.
+# Values are provided by the parent chart that includes this library.
+
+# Expected structure in parent chart's values.yaml:
+# global:
+#   labels:
+#     ark.mckinsey.com/marketplace-item: "your-service-name"

--- a/marketplace.json
+++ b/marketplace.json
@@ -15,6 +15,7 @@
       "tags": ["observability", "evaluation", "telemetry", "monitoring"],
       "category": "observability",
       "icon": "https://example.com/phoenix-icon.png",
+      "installScope": "cluster",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/phoenix/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -42,6 +43,7 @@
       "tags": ["observability", "analytics", "llm", "tracking"],
       "category": "observability",
       "icon": "https://example.com/langfuse-icon.png",
+      "installScope": "cluster",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/langfuse/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -69,6 +71,7 @@
       "tags": ["a2a", "debugging", "development", "testing", "agent2agent"],
       "category": "development",
       "icon": "https://example.com/a2a-inspector-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/a2a-inspector/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -96,6 +99,7 @@
       "tags": ["mcp", "debugging", "development", "testing"],
       "category": "development",
       "icon": "https://example.com/mcp-inspector-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/mcp-inspector/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -123,6 +127,7 @@
       "tags": ["sandbox", "execution", "containers", "mcp", "development"],
       "category": "development",
       "icon": "https://example.com/ark-sandbox-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/ark-sandbox/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -150,6 +155,7 @@
       "tags": ["agent", "administration", "mcp", "runtime"],
       "category": "agents",
       "icon": "https://example.com/noah-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/agents/noah/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -177,6 +183,7 @@
       "tags": ["s3", "storage", "mcp", "filesystem", "versitygw"],
       "category": "storage",
       "icon": "https://example.com/file-gateway-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/services/file-gateway/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -204,6 +211,7 @@
       "tags": ["demo", "kyc", "agents", "teams", "multi-agent", "onboarding"],
       "category": "demos",
       "icon": "https://example.com/kyc-demo-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/demos/kyc-demo-bundle/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -228,6 +236,7 @@
       "tags": ["mcp", "speech", "transcription", "whisper", "audio", "ai"],
       "category": "mcps",
       "icon": "https://example.com/speech-mcp-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/speech-mcp-server/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -255,6 +264,7 @@
       "tags": ["mcp", "pdf", "extraction", "ownership", "kyc", "llm"],
       "category": "mcps",
       "icon": "https://example.com/pdf-extraction-mcp-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/pdf-extraction-mcp/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -282,6 +292,7 @@
       "tags": ["mcp", "web-research", "search", "tavily", "ownership", "kyc"],
       "category": "mcps",
       "icon": "https://example.com/web-research-mcp-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/web-research-mcp/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -309,6 +320,7 @@
       "tags": ["mcp", "perplexity", "search", "ai", "web-search", "kyc"],
       "category": "mcps",
       "icon": "https://example.com/perplexity-ask-mcp-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/perplexity-ask-mcp/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -336,6 +348,7 @@
       "tags": ["mcp", "companies-house", "uk", "ownership", "kyc", "api"],
       "category": "mcps",
       "icon": "https://example.com/companies-house-mcp-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/companies-house-mcp/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -363,6 +376,7 @@
       "tags": ["demo", "cobol", "modernization", "agents", "multi-agent", "legacy", "python", "pyspark", "transcription"],
       "category": "demos",
       "icon": "https://example.com/cobol-modernization-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/demos/cobol-modernization-bundle/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -388,6 +402,7 @@
       "tags": ["demo", "kyc", "agents", "teams", "multi-agent", "onboarding", "legacyx", "workflows"],
       "category": "demos",
       "icon": "https://example.com/kyc-onboarding-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/demos/kyc-onboarding-bundle/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -413,6 +428,7 @@
       "tags": ["claude", "anthropic", "execution-engine", "agent-sdk", "tools"],
       "category": "development",
       "icon": "https://example.com/executor-claude-agent-sdk-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/executors/claude-agent-sdk/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
@@ -440,6 +456,7 @@
       "tags": ["langchain", "execution-engine", "rag", "ai", "agents"],
       "category": "development",
       "icon": "https://example.com/executor-langchain-icon.png",
+      "installScope": "namespace",
       "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/executors/executor-langchain/",
       "support": {
         "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"

--- a/services/a2a-inspector/chart/templates/_helpers.tpl
+++ b/services/a2a-inspector/chart/templates/_helpers.tpl
@@ -38,6 +38,9 @@ helm.sh/chart: {{ include "a2a-inspector.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.labels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/services/a2a-inspector/chart/values.yaml
+++ b/services/a2a-inspector/chart/values.yaml
@@ -1,9 +1,11 @@
 # A2A Inspector chart values
 
-# Global annotations
+# Global annotations and labels
 global:
   annotations:
     ark.mckinsey.com/service: a2a-inspector
+  labels:
+    ark.mckinsey.com/marketplace-item: "a2a-inspector"
 
 # Image configuration
 image:

--- a/services/mcp-inspector/chart/templates/_helpers.tpl
+++ b/services/mcp-inspector/chart/templates/_helpers.tpl
@@ -38,6 +38,9 @@ helm.sh/chart: {{ include "mcp-inspector.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.labels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/services/mcp-inspector/chart/values.yaml
+++ b/services/mcp-inspector/chart/values.yaml
@@ -1,9 +1,11 @@
 # MCP Inspector chart values
 
-# Global annotations
+# Global annotations and labels
 global:
   annotations:
     ark.mckinsey.com/service: mcp-inspector
+  labels:
+    ark.mckinsey.com/marketplace-item: "mcp-inspector"
 
 # Image configuration
 image:

--- a/services/phoenix/chart/Chart.yaml
+++ b/services/phoenix/chart/Chart.yaml
@@ -8,6 +8,9 @@ annotations:
   ark.mckinsey.com/service: phoenix
   ark.mckinsey.com/resources: service
 dependencies:
+  - name: ark-marketplace-common
+    version: "0.1.0"
+    repository: "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts"
   - name: phoenix-helm
     version: 4.0.5
     repository: oci://registry-1.docker.io/arizephoenix

--- a/services/phoenix/chart/templates/marketplace-label-patch.yaml
+++ b/services/phoenix/chart/templates/marketplace-label-patch.yaml
@@ -1,0 +1,1 @@
+{{- include "ark-marketplace.labelPatchHook" (dict "Chart" .Chart "Release" .Release "Values" .Values) }}

--- a/services/phoenix/chart/values.yaml
+++ b/services/phoenix/chart/values.yaml
@@ -1,9 +1,11 @@
 # Phoenix wrapper chart values
 
-# Global annotations
+# Global annotations and labels
 global:
   annotations:
     ark.mckinsey.com/service: phoenix
+  labels:
+    ark.mckinsey.com/marketplace-item: "phoenix"
 
 # HTTPRoute configuration (Gateway API - modern routing method)
 # Disabled by default. Enable this for Gateway API routing with namespace-based access.
@@ -45,6 +47,9 @@ otelEnvironmentVariableSecrets:
 
 # Phoenix helm chart values (passed to dependency)
 phoenix-helm:
+  # Add marketplace label to phoenix deployment
+  labels:
+    ark.mckinsey.com/marketplace-item: "phoenix"
   service:
     type: ClusterIP
   auth:


### PR DESCRIPTION
# Marketplace Label Detection Implementation

## Issue Description

Marketplace services that only create standard Kubernetes resources (Deployments, Services) cannot be detected as "Installed" by the ARK dashboard. The dashboard's existing detection mechanism relies on ARK Custom Resource Definitions (CRDs), making infrastructure services like Phoenix, A2A Inspector, and MCP Inspector invisible to installation status detection. This results in deployed services showing as "Available" instead of "Installed" in the dashboard.

## Solution Overview

Implemented label-based installation detection using the `ark.mckinsey.com/marketplace-item` label on Kubernetes deployments. For services that don't control their deployment templates (external OCI charts), created a reusable library chart (`ark-marketplace-common`) that applies labels via post-install hooks. For services with custom templates, labels are applied directly through Helm chart values.

## Changes

- Create `charts/ark-marketplace-common` Helm library chart with post-install hook template for patching external OCI chart deployments with `ark.mckinsey.com/marketplace-item` label
- Add `_marketplace-label-patch.tpl` template that creates ServiceAccount, Role, RoleBinding, and Job to patch deployments after helm install/upgrade (`charts/ark-marketplace-common/templates/`)
- Update phoenix chart to use ark-marketplace-common library with dependency in Chart.yaml and marketplace-label-patch.yaml template (`services/phoenix/chart/`)
- Add `global.labels.ark.mckinsey.com/marketplace-item` to phoenix values.yaml for external chart label application
- Update a2a-inspector and mcp-inspector charts with direct label application via `_helpers.tpl` enhancement to include global.labels (`services/a2a-inspector/chart/`, `services/mcp-inspector/chart/`)
- Enhance CI validation workflow to enforce marketplace label presence in values.yaml and verify labels on deployed resources (`.github/workflows/_reusable-charts-cicd.yaml`)
- Add comprehensive marketplace label documentation to CONTRIBUTING.md with custom chart examples, external OCI chart guidance, and troubleshooting steps
- Add ark-marketplace-common to CI/CD pipeline matrix in main-push.yaml (must publish first for dependent charts)

## Key Components

### Library Chart (ark-marketplace-common)
- **Purpose**: Apply labels to external OCI charts via post-install hooks
- **Files**: Chart.yaml, templates/_marketplace-label-patch.tpl, values.yaml, README.md
- **Usage**: Add as dependency, include hook template, configure global.labels in values.yaml

### CI Validation Enhancements
- **Validate values.yaml**: Fails if `global.labels."ark.mckinsey.com/marketplace-item"` missing
- **Verify deployment labels**: Fails if deployed resources lack marketplace label (changed from warning)
- **Label value check**: Validates label value matches chart name

### Chart Updates
- **Phoenix**: External OCI chart + library (post-install hook approach)
- **A2A Inspector**: Custom templates + direct labels
- **MCP Inspector**: Custom templates + direct labels


## Local Testing

### Testing Before GHCR Publishing

Since charts reference the library from GHCR, local testing requires manual setup:

**Manual Library Copy**
```bash
# Copy library to chart's dependencies
mkdir -p services/phoenix/chart/charts
cp -r charts/ark-marketplace-common services/phoenix/chart/charts/

# Download external chart
cd services/phoenix/chart
helm pull oci://registry-1.docker.io/arizephoenix/phoenix-helm --version 4.0.5 --untar --untardir charts/

# Install (dependencies already present, skip helm dependency update)
helm upgrade --install phoenix . -n phoenix --create-namespace

# Verify
kubectl get deployment -n phoenix -l ark.mckinsey.com/marketplace-item=phoenix
kubectl logs -n phoenix job/phoenix-label-patcher  # Check hook execution
```

### Development Tools Charts

For charts with custom templates (no external dependencies):

```bash
# A2A Inspector - no special setup needed
helm upgrade --install a2a-inspector ./services/a2a-inspector/chart -n default

# MCP Inspector - no special setup needed
helm upgrade --install mcp-inspector ./services/mcp-inspector/chart -n default

# Verify labels
kubectl get deployment -n default -l ark.mckinsey.com/marketplace-item=a2a-inspector
kubectl get deployment -n default -l ark.mckinsey.com/marketplace-item=mcp-inspector
```

**Backward Compatible**: Existing installations without labels continue to work but show as "not installed" in dashboard.