### PR TITLE
fix: use CPU-only PyTorch in speech-mcp-server to reduce build time

### DIFF
--- a/mcps/speech-mcp-server/Dockerfile
+++ b/mcps/speech-mcp-server/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
 


### PR DESCRIPTION
openai-whisper pulls in CUDA PyTorch (~2GB) by default. Pre-installing the CPU-only variant (~200MB) before requirements.txt cuts the pip install step from ~28 minutes to a few minutes. The server runs Whisper on CPU only, so CUDA support is not needed.