### PR TITLE
ci(docker): use native arm64 runners instead of QEMU emulation

### DIFF
--- a/.github/workflows/_reusable-docker-cicd.yaml
+++ b/.github/workflows/_reusable-docker-cicd.yaml
@@ -22,9 +22,17 @@ on:
         default: "latest"
 
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image - ${{ inputs.service-name }}
-    runs-on: ubuntu-24.04
+  build:
+    name: Build - ${{ inputs.service-name }} (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -44,56 +52,142 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract repository name
-        id: repo
+      - name: Compute image name
+        id: image
         run: |
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-          echo "name=$REPO_NAME" >> $GITHUB_OUTPUT
+          echo "name=ghcr.io/${{ github.repository_owner }}/${REPO_NAME}/${{ inputs.service-name }}" >> $GITHUB_OUTPUT
 
       - name: Clean image tag
         id: clean-tag
         run: |
           RAW_TAG="${{ inputs.image-tag }}"
-
-          # Strip service path prefix (e.g., 'services/noah-v0.1.0' -> 'v0.1.0')
           CLEAN_TAG="${RAW_TAG#${{ inputs.service-path }}-}"
-
-          # Strip 'v' prefix if present (e.g., 'v0.1.0' -> '0.1.0')
-          # This ensures compatibility with Helm chart appVersion
           CLEAN_TAG="${CLEAN_TAG#v}"
-
           echo "clean=$CLEAN_TAG" >> $GITHUB_OUTPUT
-          echo "Cleaned tag: $RAW_TAG -> $CLEAN_TAG"
+
+      - name: Prepare platform pair
+        id: platform
+        run: |
+          echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ steps.repo.outputs.name }}/${{ inputs.service-name }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=raw,value=${{ steps.clean-tag.outputs.clean }}
             type=raw,value=latest,enable=${{ steps.clean-tag.outputs.clean != 'latest' && inputs.push-to-registry }}
             type=sha,prefix=sha-,enable=${{ !inputs.push-to-registry }}
 
-      - name: Build Docker image
+      - name: Build and push by digest
+        if: ${{ inputs.push-to-registry }}
+        id: build-push
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.service-path }}
           file: ${{ inputs.service-path }}/Dockerfile
-          push: ${{ inputs.push-to-registry }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=${{ inputs.service-name }}-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.service-name }}-${{ steps.platform.outputs.pair }}
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Image built successfully
+      - name: Build (validation only)
+        if: ${{ !inputs.push-to-registry }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.service-path }}
+          file: ${{ inputs.service-path }}/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ inputs.service-name }}-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.service-name }}-${{ steps.platform.outputs.pair }}
+
+      - name: Export digest
+        if: ${{ inputs.push-to-registry }}
         run: |
-          echo "✓ Docker image built successfully"
+          mkdir -p /tmp/digests
+          digest="${{ steps.build-push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ inputs.push-to-registry }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.service-name }}-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Build validated
+        if: ${{ !inputs.push-to-registry }}
+        run: |
+          echo "Docker image build validated"
+          echo "Service: ${{ inputs.service-name }}"
+          echo "Platform: ${{ matrix.platform }}"
+
+  merge:
+    name: Create manifest - ${{ inputs.service-name }}
+    if: ${{ inputs.push-to-registry }}
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ inputs.service-name }}-*
+          merge-multiple: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name
+        id: image
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          echo "name=ghcr.io/${{ github.repository_owner }}/${REPO_NAME}/${{ inputs.service-name }}" >> $GITHUB_OUTPUT
+
+      - name: Clean image tag
+        id: clean-tag
+        run: |
+          RAW_TAG="${{ inputs.image-tag }}"
+          CLEAN_TAG="${RAW_TAG#${{ inputs.service-path }}-}"
+          CLEAN_TAG="${CLEAN_TAG#v}"
+          echo "clean=$CLEAN_TAG" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=raw,value=${{ steps.clean-tag.outputs.clean }}
+            type=raw,value=latest,enable=${{ steps.clean-tag.outputs.clean != 'latest' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="${{ steps.image.outputs.name }}"
+          DIGESTS=$(printf "${IMAGE}@sha256:%s " *)
+          echo "${{ steps.meta.outputs.tags }}" | while read -r TAG; do
+            echo "Creating manifest for: ${TAG}"
+            docker buildx imagetools create --tag "${TAG}" ${DIGESTS}
+          done
+
+      - name: Image pushed successfully
+        run: |
+          echo "Multi-arch Docker image pushed successfully"
           echo "Service: ${{ inputs.service-name }}"
           echo "Tags: ${{ steps.meta.outputs.tags }}"
-          if [ "${{ inputs.push-to-registry }}" = "true" ]; then
-            echo "✓ Image pushed to registry"
-          else
-            echo "ℹ️  Image not pushed (dry-run mode)"
-          fi


### PR DESCRIPTION
## Summary

- Replace single-job QEMU cross-compilation with parallel native builds on `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64)
- Add a manifest merge job that combines per-platform digests into a multi-arch image when pushing
- Scope GHA build cache per service and platform for better hit rates
- Dry-run (PR validation) builds still run on both platforms natively, just without push

## Test plan

- [ ] PR validation workflow builds both platforms without errors
- [ ] Release workflow pushes multi-arch image with correct manifest
- [ ] `docker manifest inspect` shows both amd64 and arm64 entries
- [ ] speech-mcp-server build time drops significantly

Fixes #184