### PR TITLE
feat: marketplace install detection and url discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,12 @@ Each marketplace item should include:
    - Usage examples
    - Troubleshooting
 
-3. **Helm Chart** (for services): 
+3. **Helm Chart** (for services):
    - Place in `chart/` subdirectory
-   - Include `Chart.yaml` with proper metadata
+   - Include `Chart.yaml` with proper metadata (see [Marketplace Setup Guide](https://mckinsey.github.io/agents-at-scale-marketplace/marketplace-setup))
    - Provide `values.yaml` with sensible defaults
    - Include necessary templates
+   - For services with web UIs, configure UI URL annotations (see [Marketplace Setup Guide](https://mckinsey.github.io/agents-at-scale-marketplace/marketplace-setup#ui-url-configuration))
 
 4. **DevSpace Configuration** (recommended):
    - `devspace.yaml` for local development
@@ -99,6 +100,8 @@ Before submitting:
 - Verify all documentation is accurate
 - Ensure examples work as described
 - Check that your item integrates properly with the Ark platform
+
+For detailed information on configuring chart annotations and UI URLs, see the [Marketplace Setup Guide](https://mckinsey.github.io/agents-at-scale-marketplace/marketplace-setup).
 
 **Language and Technology Choices**
 

--- a/agents/noah/chart/Chart.yaml
+++ b/agents/noah/chart/Chart.yaml
@@ -7,3 +7,4 @@ appVersion: 0.1.0
 annotations:
   ark.mckinsey.com/service: noah
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: "agent/noah"

--- a/demos/kyc-demo-bundle/chart/Chart.yaml
+++ b/demos/kyc-demo-bundle/chart/Chart.yaml
@@ -20,6 +20,7 @@ annotations:
   ark.mckinsey.com/type: bundle
   ark.mckinsey.com/use-case: kyc
   ark.mckinsey.com/components: agents,teams
+  ark.mckinsey.com/marketplace-item-name: "demo/kyc-demo-bundle"
 dependencies:
   - name: file-gateway
     version: 0.1.6

--- a/docs/content/_meta.js
+++ b/docs/content/_meta.js
@@ -1,5 +1,6 @@
 export default {
   index: 'Introduction',
+  'marketplace-setup': 'Marketplace Setup',
   executors: 'Executors',
   services: 'Services',
   mcps: 'MCP Servers',

--- a/docs/content/marketplace-setup.mdx
+++ b/docs/content/marketplace-setup.mdx
@@ -1,0 +1,204 @@
+---
+title: Marketplace Setup Guide
+description: Configure your Helm charts for Ark marketplace integration
+---
+
+# Marketplace Setup Guide
+
+This guide explains how to configure your marketplace items for proper installation detection and UI integration in the Ark dashboard.
+
+## Chart Annotations
+
+All marketplace items must include the `ark.mckinsey.com/marketplace-item-name` annotation in `Chart.yaml` for proper installation detection:
+
+```yaml
+# Chart.yaml
+apiVersion: v2
+name: your-service-name
+version: 0.1.0
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "<category>/<name>"
+```
+
+### Category Prefixes
+
+- `service/` - Platform services (e.g., `service/phoenix`)
+- `agent/` - Agents (e.g., `agent/noah`)
+- `mcp/` - MCP servers (e.g., `mcp/speech-mcp-server`)
+- `demo/` - Demo bundles (e.g., `demo/kyc-demo-bundle`)
+
+This annotation enables the Ark dashboard to detect when your item is installed via Helm, regardless of the release name chosen by the user.
+
+**Important:** Marketplace items are detected only when installed in the same namespace as `ark-api`. Ensure your item is deployed to the correct namespace for proper detection.
+
+## UI URL Configuration
+
+For services with web UIs, enable the Ark dashboard to display "Open" buttons by adding UI URL annotations to your Service resource.
+
+### Method 1: Direct Service Template
+
+Use this method for charts that create their own Service resources.
+
+#### Service Template
+
+Add to your `templates/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "your-chart.fullname" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    {{- if .Values.uiUrl }}
+    ark.mckinsey.com/marketplace-item-ui-url: {{ .Values.uiUrl | quote }}
+    {{- end }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: {{ .Values.uiLabel | quote }}
+    {{- end }}
+spec:
+  # ... service spec
+```
+
+#### Values Configuration
+
+Add to your `values.yaml`:
+
+```yaml
+# Set uiUrl and uiLabel when installing to make the UI accessible from the dashboard
+# Example: --set uiUrl=https://your-service.example.com --set uiLabel="Dashboard"
+uiUrl: ""
+uiLabel: ""
+```
+
+#### Installation Example
+
+```bash
+helm install my-service ./chart \
+  --set uiUrl=https://my-service.example.com \
+  --set uiLabel="Service Dashboard"
+```
+
+### Method 2: Wrapper Chart Pattern
+
+Use this method for charts wrapping external Helm dependencies (e.g., phoenix wraps phoenix-helm, langfuse wraps langfuse).
+
+#### Values Configuration
+
+Add to your `values.yaml`:
+
+```yaml
+# UI configuration
+# Set these when installing to make the UI accessible from the dashboard
+# For wrapper charts, annotations must be passed to the dependency's service:
+# --set your-dependency.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-url=https://example.com
+# --set your-dependency.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-label="Dashboard"
+uiUrl: ""
+uiLabel: ""
+
+# Dependency chart values (passed to dependency)
+your-dependency-name:
+  service:
+    labels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+    annotations: {}
+```
+
+#### Installation Example
+
+```bash
+helm install my-service ./chart \
+  --set 'dependency-name.service.annotations.ark\.mckinsey\.com/marketplace-item-ui-url'=https://my-service.example.com \
+  --set 'dependency-name.service.annotations.ark\.mckinsey\.com/marketplace-item-ui-label'="Service Dashboard"
+```
+
+**Note:** The exact path to the service annotations depends on your dependency chart's structure. For example:
+- Phoenix: `phoenix-helm.service.annotations.*`
+- Langfuse: `langfuse.langfuse.web.service.annotations.*`
+
+Consult your dependency chart's values.yaml to determine the correct path.
+
+## Important Notes
+
+- **Namespace Label**: The `app.kubernetes.io/instance` label is automatically set by Helm and is used by the Ark dashboard to query Services
+- **Optional UI Label**: The UI label is optional; if omitted, the dashboard displays "Open" as the button text
+- **Multiple UIs**: Multiple Services can have UI annotations for items with multiple web interfaces (e.g., separate admin and user dashboards)
+- **URL Configuration**: The URL should be the externally-reachable URL configured in your Ingress, Gateway API route, or LoadBalancer service
+
+## Examples
+
+### Direct Service Pattern: A2A Inspector
+
+```yaml
+# Chart.yaml
+apiVersion: v2
+name: a2a-inspector
+version: 0.1.1
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "service/a2a-inspector"
+```
+
+```yaml
+# templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "a2a-inspector.fullname" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    {{- if .Values.uiUrl }}
+    ark.mckinsey.com/marketplace-item-ui-url: {{ .Values.uiUrl | quote }}
+    {{- end }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: {{ .Values.uiLabel | quote }}
+    {{- end }}
+```
+
+```yaml
+# values.yaml
+uiUrl: ""
+uiLabel: ""
+```
+
+```bash
+# Installation
+helm install a2a-inspector ./chart \
+  --set uiUrl=https://a2a-inspector.example.com \
+  --set uiLabel="A2A Inspector"
+```
+
+### Wrapper Chart Pattern: Phoenix
+
+```yaml
+# Chart.yaml
+apiVersion: v2
+name: phoenix
+version: 0.1.7
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "service/phoenix"
+dependencies:
+  - name: phoenix-helm
+    version: 4.0.5
+    repository: oci://registry-1.docker.io/arizephoenix
+```
+
+```yaml
+# values.yaml
+uiUrl: ""
+uiLabel: ""
+
+phoenix-helm:
+  service:
+    labels:
+      app.kubernetes.io/instance: phoenix
+    annotations: {}
+```
+
+```bash
+# Installation
+helm install phoenix ./chart \
+  --set 'phoenix-helm.service.annotations.ark\.mckinsey\.com/marketplace-item-ui-url'=https://phoenix.example.com \
+  --set 'phoenix-helm.service.annotations.ark\.mckinsey\.com/marketplace-item-ui-label'="Phoenix Dashboard"
+```

--- a/mcps/speech-mcp-server/chart/Chart.yaml
+++ b/mcps/speech-mcp-server/chart/Chart.yaml
@@ -4,3 +4,5 @@ description: MCP server for audio transcription via Whisper
 type: application
 version: 0.1.1
 appVersion: 0.1.0
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "mcp/speech-mcp-server"

--- a/services/a2a-inspector/chart/Chart.yaml
+++ b/services/a2a-inspector/chart/Chart.yaml
@@ -7,3 +7,4 @@ appVersion: 0.1.0
 annotations:
   ark.mckinsey.com/service: a2a-inspector
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: "service/a2a-inspector"

--- a/services/a2a-inspector/chart/templates/service.yaml
+++ b/services/a2a-inspector/chart/templates/service.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "a2a-inspector.labels" . | nindent 4 }}
+  {{- if .Values.uiUrl }}
+  annotations:
+    ark.mckinsey.com/marketplace-item-ui-url: {{ .Values.uiUrl | quote }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: {{ .Values.uiLabel | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/services/a2a-inspector/chart/values.yaml
+++ b/services/a2a-inspector/chart/values.yaml
@@ -19,6 +19,12 @@ service:
   type: ClusterIP
   port: 8080
 
+# UI URL configuration
+# Set uiUrl and uiLabel when installing to make the UI accessible from the dashboard
+# Example: --set uiUrl=https://a2a-inspector.example.com --set uiLabel="A2A Inspector"
+uiUrl: ""
+uiLabel: ""
+
 # Namespace configuration
 namespace: default
 

--- a/services/ark-sandbox/chart/Chart.yaml
+++ b/services/ark-sandbox/chart/Chart.yaml
@@ -7,3 +7,4 @@ appVersion: 0.1.0
 annotations:
   ark.mckinsey.com/service: ark-sandbox
   ark.mckinsey.com/resources: service,crds
+  ark.mckinsey.com/marketplace-item-name: "service/ark-sandbox"

--- a/services/file-gateway/chart/Chart.yaml
+++ b/services/file-gateway/chart/Chart.yaml
@@ -12,3 +12,5 @@ keywords:
   - mcp
   - filesystem
   - storage
+annotations:
+  ark.mckinsey.com/marketplace-item-name: "service/file-gateway"

--- a/services/langfuse/chart/Chart.yaml
+++ b/services/langfuse/chart/Chart.yaml
@@ -6,6 +6,7 @@ appVersion: 1.5.7
 annotations:
   ark.mckinsey.com/service: langfuse
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: "service/langfuse"
 dependencies:
   - name: langfuse
     version: 1.5.7

--- a/services/langfuse/chart/values.yaml
+++ b/services/langfuse/chart/values.yaml
@@ -48,6 +48,14 @@ service:
 # Namespace configuration
 namespace: telemetry
 
+# UI URL configuration
+# Set these when installing to make the UI accessible from the dashboard
+# For wrapper charts, annotations must be passed to the dependency's web service:
+# --set langfuse.langfuse.web.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-url=https://langfuse.example.com
+# --set langfuse.langfuse.web.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-label="Langfuse Dashboard"
+uiUrl: ""
+uiLabel: ""
+
 # Demo configuration
 demo:
   user:
@@ -77,6 +85,12 @@ otelEnvironmentVariableSecrets:
 
 # Langfuse helm chart values (passed to dependency)
 langfuse:
+  service:
+    # Labels required for marketplace detection
+    # The app.kubernetes.io/instance label must match the Helm release name
+    labels:
+      app.kubernetes.io/instance: langfuse
+    annotations: {}
   langfuse:
     nextauth:
       secret:

--- a/services/mcp-inspector/chart/Chart.yaml
+++ b/services/mcp-inspector/chart/Chart.yaml
@@ -7,3 +7,4 @@ appVersion: 0.16.5
 annotations:
   ark.mckinsey.com/service: mcp-inspector
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: "service/mcp-inspector"

--- a/services/mcp-inspector/chart/templates/service.yaml
+++ b/services/mcp-inspector/chart/templates/service.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mcp-inspector.labels" . | nindent 4 }}
+  {{- if .Values.uiUrl }}
+  annotations:
+    ark.mckinsey.com/marketplace-item-ui-url: {{ .Values.uiUrl | quote }}
+    {{- if .Values.uiLabel }}
+    ark.mckinsey.com/marketplace-item-ui-label: {{ .Values.uiLabel | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/services/mcp-inspector/chart/values.yaml
+++ b/services/mcp-inspector/chart/values.yaml
@@ -20,6 +20,12 @@ service:
   clientPort: 6274
   proxyPort: 6277
 
+# UI URL configuration
+# Set uiUrl and uiLabel when installing to make the UI accessible from the dashboard
+# Example: --set uiUrl=https://mcp-inspector.example.com --set uiLabel="MCP Inspector"
+uiUrl: ""
+uiLabel: ""
+
 # Namespace configuration
 namespace: default
 

--- a/services/phoenix/chart/Chart.yaml
+++ b/services/phoenix/chart/Chart.yaml
@@ -7,6 +7,7 @@ appVersion: 4.0.5
 annotations:
   ark.mckinsey.com/service: phoenix
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: "service/phoenix"
 dependencies:
   - name: phoenix-helm
     version: 4.0.5

--- a/services/phoenix/chart/values.yaml
+++ b/services/phoenix/chart/values.yaml
@@ -25,6 +25,14 @@ service:
   name: phoenix-svc
   port: 6006
 
+# UI URL configuration
+# Set uiUrl and uiLabel when installing to make the UI accessible from the dashboard
+# For wrapper charts, annotations must be passed to the dependency's web service:
+# --set phoenix-helm.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-url=https://phoenix.example.com
+# --set phoenix-helm.service.annotations.ark\\.mckinsey\\.com/marketplace-item-ui-label="Phoenix Dashboard"
+uiUrl: ""
+uiLabel: ""
+
 # Namespace configuration
 namespace: phoenix
 
@@ -47,6 +55,11 @@ otelEnvironmentVariableSecrets:
 phoenix-helm:
   service:
     type: ClusterIP
+    # Labels required for marketplace detection
+    # The app.kubernetes.io/instance label must match the Helm release name
+    labels:
+      app.kubernetes.io/instance: phoenix
+    annotations: {}
   auth:
     enableAuth: false
   ingress:


### PR DESCRIPTION
## Changes

### Chart Annotations for Install Detection
- Added `ark.mckinsey.com/marketplace-item-name` annotation to all marketplace item Chart.yaml files
- Enables Ark dashboard to detect installed items via Helm chart metadata matching
- Uses category prefixes: `service/`, `agent/`, `mcp/`, `demo/` for item classification
- Applied to 15 charts across services, agents, MCPs, and demo bundles

### UI URL and Label Configuration
- Added Service template annotations for web UI access on 4 services with UIs:
  - Phoenix (`service/phoenix`)
  - Langfuse (`service/langfuse`)
  - A2A Inspector (`service/a2a-inspector`)
  - MCP Inspector (`service/mcp-inspector`)
- Annotations include:
  - `ark.mckinsey.com/marketplace-item-ui-url` for the externally-reachable URL
  - `ark.mckinsey.com/marketplace-item-ui-label` for custom button text (optional)

### Values Configuration
- Added `uiUrl` and `uiLabel` fields to values.yaml for all services with UIs
- Direct service charts: annotations templated from `.Values.uiUrl` and `.Values.uiLabel`
- Wrapper charts (Phoenix, Langfuse): annotations passed through to dependency service
- Includes installation examples and documentation in values files

### Service Labels
- Added `app.kubernetes.io/instance` label configuration to wrapper charts
- Required for Ark dashboard to query Services by Helm release name
- Phoenix and Langfuse configured to pass labels to dependency charts

### Documentation
- Created comprehensive marketplace setup guide (`docs/content/marketplace-setup.mdx`)
- Documents chart annotation requirements for installation detection
- Provides patterns for both direct service charts and wrapper charts
- Includes installation examples with and without UI URL configuration
- Updated CONTRIBUTING.md to reference new setup guide

## Integration with Ark Dashboard

These changes enable the Ark dashboard (via PR #1767) to:
- Detect installed marketplace items by matching chart annotations to marketplace.json names
- Display "Open" buttons (or custom labels) for services with configured UI URLs
- Support multiple UIs per marketplace item via multiple Service annotations
