### PR TITLE
feat(openai-responses): improve example agents and docs

### DIFF
--- a/docs/content/executors/openai-responses.mdx
+++ b/docs/content/executors/openai-responses.mdx
@@ -115,7 +115,9 @@ annotations:
   executor-openai-responses.ark.mckinsey.com/reasoning: '{"effort": "low"}'
 ```
 
-Effort values: `"low"`, `"medium"`, `"high"`. Note: `"minimal"` is not supported when using web search tools.
+Effort values: `"low"`, `"medium"`, `"high"`. Omitting the annotation defaults to `"medium"`.
+
+Use `"low"` for focused single-task agents (e.g. find one URL). Use `"medium"` or higher for agents that must gather multiple pieces of information (e.g. structured lookup with web search across several fields) — lower effort may not perform enough searches to find all required data.
 
 ### Structured Output
 
@@ -137,7 +139,27 @@ annotations:
 
 ## Examples
 
-See [`examples/`](https://github.com/mckinsey/agents-at-scale-marketplace/tree/main/executors/openai-responses/examples) for ready-to-use YAML manifests:
+See [`examples/`](https://github.com/mckinsey/agents-at-scale-marketplace/tree/main/executors/openai-responses/examples) for ready-to-use YAML manifests and demo scripts.
+
+### Running the demo
+
+Against a live cluster:
+
+```bash
+# Apply all CRDs and run each example, printing prompt, input and response
+examples/demo.sh
+```
+
+Locally without Kubernetes:
+
+```bash
+export OPENAI_API_KEY=sk-...
+export OPENAI_BASE_URL=https://your-endpoint  # optional
+export MODEL_NAME=gpt-5.2-2025-12-11         # optional
+python3 examples/demo_local.py
+```
+
+### Example manifests
 
 | Example | What it shows |
 |---------|--------------|

--- a/executors/openai-responses/examples/companies-house-agent.yaml
+++ b/executors/openai-responses/examples/companies-house-agent.yaml
@@ -26,7 +26,7 @@ spec:
   provider: openai
   type: completions
   model:
-    value: gpt-5-nano-2025-08-07
+    value: gpt-5.2-2025-12-11
   config:
     openai:
       apiKey:

--- a/executors/openai-responses/examples/company-lookup-agent.yaml
+++ b/executors/openai-responses/examples/company-lookup-agent.yaml
@@ -32,7 +32,7 @@ spec:
   provider: openai
   type: completions
   model:
-    value: gpt-5-nano-2025-08-07
+    value: gpt-5.2-2025-12-11
   config:
     openai:
       apiKey:
@@ -55,7 +55,7 @@ kind: Agent
 metadata:
   name: company-lookup-agent
   annotations:
-    executor-openai-responses.ark.mckinsey.com/reasoning: '{"effort": "low"}'
+    executor-openai-responses.ark.mckinsey.com/reasoning: '{"effort": "medium"}'
     executor-openai-responses.ark.mckinsey.com/tools: |
       [
         {
@@ -103,14 +103,13 @@ spec:
     name: executor-openai-responses
   prompt: |
     You are a company research assistant located in the UK.
-    Given a company name, search the web to find accurate, up-to-date information
-    and return it as structured data. Always search for:
+    Given a company name, search the web to find accurate, up-to-date information and return it as structured data.
+    Search for the following fields:
     1. The official registered company name
-    2. The primary website URL
-    3. The UK Companies House registration number (if it is a UK-registered company)
+    2. The primary website URL — search specifically for the company's own domain. If you find a plausible website for the business, include it even if the registered legal name does not appear verbatim on the site. Never use Companies House, LinkedIn, Yell, Google Maps, or any directory. Set to empty string only if no website exists at all.
+    3. The UK Companies House registration number
     4. The official registered address
     5. The current company status (Active, Dissolved, etc.)
-    If any field cannot be found, set it to null. Always verify via web search.
 ---
 # 3. Query CR — runtime input per request
 #    spec.input → company name to look up

--- a/executors/openai-responses/examples/dsl-generator-agent.yaml
+++ b/executors/openai-responses/examples/dsl-generator-agent.yaml
@@ -30,7 +30,7 @@ spec:
   provider: openai
   type: completions
   model:
-    value: gpt-5-nano-2025-08-07
+    value: gpt-5.2-2025-12-11
   config:
     openai:
       apiKey:

--- a/executors/openai-responses/examples/sql-generator-agent.yaml
+++ b/executors/openai-responses/examples/sql-generator-agent.yaml
@@ -8,7 +8,7 @@
 # Requires:
 #   - executor-openai-responses deployed
 #   - Secret openai-credentials with api-key and base-url
-#   - Model gpt-5-nano-2025-08-07 or newer (CFG is a gpt-5 feature)
+#   - Model gpt-5.2-2025-12-11 or newer (CFG is a gpt-5 feature)
 # ──────────────────────────────────────────────────────────────────────────────
 
 # 1. Model CR
@@ -20,7 +20,7 @@ spec:
   provider: openai
   type: completions
   model:
-    value: gpt-5-nano-2025-08-07
+    value: gpt-5.2-2025-12-11
   config:
     openai:
       apiKey:

--- a/executors/openai-responses/examples/website-search-agent.yaml
+++ b/executors/openai-responses/examples/website-search-agent.yaml
@@ -25,7 +25,7 @@ spec:
   provider: openai
   type: completions
   model:
-    value: gpt-5-nano-2025-08-07
+    value: gpt-5.2-2025-12-11
   config:
     openai:
       apiKey:
@@ -67,8 +67,9 @@ spec:
     name: executor-openai-responses
   prompt: |
     You are an expert web search agent located in UK.
-    Your role is to find the link to the main website of a given company located in UK.
-    Return only the link and nothing else. Do not write any comments or explanation.
+    Your role is to find the official business website of a given UK company.
+    Search the web and return only the company's own domain — never return URLs from Companies House, LinkedIn, Yell, Google Maps, or any directory or government service.
+    Return only the URL, nothing else.
 ---
 # 3. Query CR — runtime input per request
 #    spec.input     → Responses API `input`  (user turn message)

--- a/executors/openai-responses/src/openai_responses_executor/executor.py
+++ b/executors/openai-responses/src/openai_responses_executor/executor.py
@@ -137,8 +137,11 @@ class OpenAIResponsesExecutor(BaseExecutor):
         conversation_id: str,
     ) -> list[Message]:
         for iteration in range(config.max_tool_iterations):
-            response = await client.responses.create(**params.to_api_kwargs())
+            api_kwargs = params.to_api_kwargs()
+            logger.info(f"Request tools: {api_kwargs.get('tools')}")
+            response = await client.responses.create(**api_kwargs)
             self._save_response_id(conversation_id, response.id)
+            logger.info(f"Response output types: {[getattr(item, 'type', None) for item in response.output]}")
 
             function_calls = self._extract_function_calls(response)
 


### PR DESCRIPTION
## Summary
- Update example YAMLs to use gpt-5.2-2025-12-11
- Improve company-lookup-agent prompt to reliably find website URLs via web search
- Set reasoning effort to medium for company-lookup-agent
- Add executor debug logging for request tools and response output types
- Update docs with reasoning effort guidance