### PR TITLE
docs: add openspec spec for executor broker streaming

### DIFF
--- a/openspec/changes/executor-broker-streaming/.openspec.yaml
+++ b/openspec/changes/executor-broker-streaming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/executor-broker-streaming/design.md
+++ b/openspec/changes/executor-broker-streaming/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The ark-sdk `ExecutorApp` injects a `BrokerClient` into `BaseExecutor` before calling `execute_agent()`. Executors opt in to real-time streaming by calling `await self.stream_chunk(token)` as content is generated. If no calls are made, `ExecutorApp` falls back to a single chunk at the end (Phase 1 behaviour). Each marketplace executor has its own streaming loop that needs a one-line integration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Token-by-token streaming to the broker for all three marketplace executors
+- Minimal, localised change per executor — one call per token in the existing streaming loop
+- No change to `execute_agent()` return type or caller interface
+
+**Non-Goals:**
+- Changes to the broker client or chunk format (owned by ark-sdk)
+- Streaming support for non-streaming model configurations
+- LangChain executors that don't use streaming callbacks
+
+## Decisions
+
+### Decision: Call `stream_chunk()` inside existing streaming loops
+
+Each executor already has a streaming path (OpenAI stream events, Anthropic stream events, LangChain callbacks). The integration is a single `await self.stream_chunk(token)` call at the point each token is available. No restructuring of executor logic needed.
+
+### Decision: Accumulate full response independently of streaming
+
+Executors already accumulate the full response to return from `execute_agent()`. The `stream_chunk()` call is additive — it does not replace accumulation. This ensures the A2A response and `Query.status.response` remain correct regardless of broker availability.
+
+## Risks / Trade-offs
+
+- **Requires ark-sdk Phase 2**: Executors calling `stream_chunk()` on an older SDK version will get an `AttributeError`. Mitigation: pin ark-sdk version in each executor's `pyproject.toml` and release together.
+- **Double chunk if Phase 1 fallback triggers**: If `stream_chunk()` is called but `complete()` is not properly signalled, the broker may receive both streamed chunks and a final single chunk. Mitigation: ark-sdk handles this — if any `stream_chunk()` calls were made, the single-chunk fallback is skipped.
+
+## Open Questions
+
+- Should executors guard `stream_chunk()` with `hasattr` for backward compatibility with older SDK versions? (Defer to implementation — depends on release coordination.)

--- a/openspec/changes/executor-broker-streaming/proposal.md
+++ b/openspec/changes/executor-broker-streaming/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The ark-sdk `ExecutorApp` now supports real-time broker streaming via `stream_chunk()` on `BaseExecutor` (Phase 2 of mckinsey/agents-at-scale-ark#1891). Marketplace executors need to adopt it to deliver token-by-token streaming to the dashboard and CLI.
+
+## What Changes
+
+- `openai-responses` executor calls `await self.stream_chunk(token)` as tokens arrive from the OpenAI Responses API streaming loop
+- `claude-agent-sdk` executor calls `await self.stream_chunk(token)` as tokens arrive from the Anthropic streaming API
+- `langchain` executor calls `await self.stream_chunk(token)` as tokens arrive from LangChain streaming callbacks
+- All three executors continue to return the full accumulated response from `execute_agent()` unchanged
+
+## Capabilities
+
+### New Capabilities
+- `executor-broker-streaming`: marketplace executors stream tokens to the ark-broker in real time during `execute_agent()` by calling `self.stream_chunk()`
+
+### Modified Capabilities
+
+## Impact
+
+- `executors/openai-responses/` — streaming loop calls `self.stream_chunk(token)`
+- `executors/claude-agent-sdk/` — streaming callback calls `self.stream_chunk(token)`
+- `executors/langchain/` — streaming handler calls `self.stream_chunk(token)`
+- Requires ark-sdk version with `stream_chunk()` on `BaseExecutor` (Phase 2)

--- a/openspec/changes/executor-broker-streaming/specs/executor-broker-streaming/spec.md
+++ b/openspec/changes/executor-broker-streaming/specs/executor-broker-streaming/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: openai-responses executor streams tokens to broker
+
+The `openai-responses` executor SHALL call `await self.stream_chunk(token)` for each token received from the OpenAI Responses API streaming loop inside `execute_agent()`.
+
+#### Scenario: openai-responses streams tokens during execution
+
+- **WHEN** `execute_agent()` is called and the OpenAI Responses API returns a streaming response
+- **THEN** each token is forwarded to the broker via `self.stream_chunk(token)` as it arrives
+- **AND** the full accumulated response is still returned from `execute_agent()`
+
+#### Scenario: openai-responses falls back when streaming unavailable
+
+- **WHEN** `execute_agent()` is called and the model is configured for non-streaming
+- **THEN** no `stream_chunk()` calls are made and the single-chunk fallback in `ExecutorApp` handles broker delivery
+
+### Requirement: claude-agent-sdk executor streams tokens to broker
+
+The `claude-agent-sdk` executor SHALL call `await self.stream_chunk(token)` for each text delta received from the Anthropic streaming API inside `execute_agent()`.
+
+#### Scenario: claude-agent-sdk streams tokens during execution
+
+- **WHEN** `execute_agent()` is called and the Anthropic API returns a streaming response
+- **THEN** each text delta is forwarded to the broker via `self.stream_chunk(token)` as it arrives
+- **AND** the full accumulated response is still returned from `execute_agent()`
+
+### Requirement: langchain executor streams tokens to broker
+
+The `langchain` executor SHALL call `await self.stream_chunk(token)` for each token received via the LangChain streaming callback inside `execute_agent()`.
+
+#### Scenario: langchain streams tokens during execution
+
+- **WHEN** `execute_agent()` is called with a LangChain chain configured for streaming
+- **THEN** each token from the streaming callback is forwarded to the broker via `self.stream_chunk(token)`
+- **AND** the full accumulated response is still returned from `execute_agent()`

--- a/openspec/changes/executor-broker-streaming/tasks.md
+++ b/openspec/changes/executor-broker-streaming/tasks.md
@@ -1,0 +1,22 @@
+## 1. openai-responses executor
+
+- [ ] 1.1 Add `await self.stream_chunk(token)` in the OpenAI Responses API streaming loop
+- [ ] 1.2 Unit test that `stream_chunk()` is called once per token during streaming execution
+- [ ] 1.3 Unit test that full response is still returned from `execute_agent()` correctly
+
+## 2. claude-agent-sdk executor
+
+- [ ] 2.1 Add `await self.stream_chunk(token)` for each text delta in the Anthropic streaming callback
+- [ ] 2.2 Unit test that `stream_chunk()` is called once per text delta
+- [ ] 2.3 Unit test that full response is still returned from `execute_agent()` correctly
+
+## 3. langchain executor
+
+- [ ] 3.1 Add `await self.stream_chunk(token)` in the LangChain streaming callback handler
+- [ ] 3.2 Unit test that `stream_chunk()` is called once per token via the callback
+- [ ] 3.3 Unit test that full response is still returned from `execute_agent()` correctly
+
+## 4. Release coordination
+
+- [ ] 4.1 Pin ark-sdk version with `stream_chunk()` support in each executor's `pyproject.toml`
+- [ ] 4.2 Verify end-to-end: submit query, confirm incremental chunks appear in broker SSE stream


### PR DESCRIPTION
## Summary
- Adds OpenSpec change `executor-broker-streaming` with proposal, design, specs, and tasks
- Covers adoption of `stream_chunk()` on `BaseExecutor` (Phase 2) for all three marketplace executors: `openai-responses`, `claude-agent-sdk`, `langchain`
- Depends on mckinsey/agents-at-scale-ark#1891