### PR TITLE
feat: inject credentials into claude code executor

### DIFF
--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -31,16 +31,18 @@ helm install executor-claude-agent-sdk ./chart -n default --create-namespace --s
 Create a Model CRD with your Anthropic configuration:
 
 ```yaml
-apiVersion: ark.mckinsey.com/v1
+apiVersion: ark.mckinsey.com/v1alpha1
 kind: Model
 metadata:
   name: claude-sonnet
 spec:
   model:
     value: claude-sonnet-4-6
-  type: anthropic
+  provider: anthropic
   config:
     anthropic:
+      baseUrl:
+        value: my-base-url
       apiKey:
         valueFrom:
           secretKeyRef:
@@ -68,8 +70,8 @@ metadata:
 spec:
   executionEngine:
     name: executor-claude-agent-sdk
-  model:
-    ref: claude-sonnet
+  modelRef:
+    name: claude-sonnet
   prompt: |
     You are a helpful assistant with access to filesystem tools.
 ```

--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -183,7 +183,7 @@ extraEnvFrom:
 
 ```bash
 helm upgrade executor-claude-agent-sdk ./chart \
-  --set extraEnvFrom[0].secretRef.name=github-credentials
+  --set 'extraEnvFrom[0].secretRef.name=github-credentials'
 ```
 
 ### How It Works
@@ -201,7 +201,7 @@ kubectl create secret generic github-credentials \
 
 # Install executor with credentials
 helm install executor-claude-agent-sdk ./chart \
-  --set extraEnvFrom[0].secretRef.name=github-credentials
+  --set 'extraEnvFrom[0].secretRef.name=github-credentials'
 
 # Create an agent that uses gh CLI
 kubectl apply -f - <<EOF
@@ -212,15 +212,15 @@ metadata:
 spec:
   executionEngine:
     name: executor-claude-agent-sdk
-  model:
-    ref: claude-sonnet
+  modelRef:
+    name: claude-sonnet
   prompt: |
     You are a GitHub automation assistant.
     Use the gh CLI to interact with repositories.
 EOF
 
 # Query the agent
-ark query github-agent "Create a PR in myorg/myrepo with title 'Update README'"
+ark query agent/github-agent "Create a PR in myorg/myrepo with title 'Update README'"
 ```
 
 The agent will now have access to `GITHUB_TOKEN` and can use `gh` CLI commands that require authentication.

--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -154,3 +154,92 @@ Model name and API key are configured via the Model CRD (see [Prerequisites](#pr
 |----------|-------------|---------|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint for tracing | Disabled |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OTLP auth headers | None |
+
+## Credential Injection
+
+The executor supports injecting credentials from Kubernetes Secrets as environment variables into Claude Code sessions. This enables agents to authenticate with external services like GitHub, Git, or APIs.
+
+### Setup
+
+1. Create a Kubernetes Secret with your credentials:
+
+```bash
+kubectl create secret generic github-credentials \
+  --from-literal=GITHUB_TOKEN=ghp_xxxxxxxxxxxxx
+```
+
+2. Configure the executor to load the secret via `extraEnvFrom` in your Helm values:
+
+```yaml
+# values.yaml or --set flag
+extraEnvFrom:
+  - secretRef:
+      name: github-credentials
+```
+
+3. Deploy or upgrade the executor:
+
+```bash
+helm upgrade executor-claude-agent-sdk ./chart \
+  --set extraEnvFrom[0].secretRef.name=github-credentials
+```
+
+### How It Works
+
+- Environment variables from the executor pod (including those loaded from Secrets via `extraEnvFrom`) are forwarded to the Claude Code subprocess
+- Tools like `gh`, `git`, and `curl` automatically discover credentials from the environment
+- Credentials are scoped per-deployment — all agents using this executor instance share the same credentials
+
+### Example: GitHub Authentication
+
+```bash
+# Create secret with GitHub token
+kubectl create secret generic github-credentials \
+  --from-literal=GITHUB_TOKEN=ghp_xxxxxxxxxxxxx
+
+# Install executor with credentials
+helm install executor-claude-agent-sdk ./chart \
+  --set extraEnvFrom[0].secretRef.name=github-credentials
+
+# Create an agent that uses gh CLI
+kubectl apply -f - <<EOF
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: github-agent
+spec:
+  executionEngine:
+    name: executor-claude-agent-sdk
+  model:
+    ref: claude-sonnet
+  prompt: |
+    You are a GitHub automation assistant.
+    Use the gh CLI to interact with repositories.
+EOF
+
+# Query the agent
+ark query github-agent "Create a PR in myorg/myrepo with title 'Update README'"
+```
+
+The agent will now have access to `GITHUB_TOKEN` and can use `gh` CLI commands that require authentication.
+
+### Multiple Secrets
+
+You can inject multiple secrets by adding more entries to `extraEnvFrom`:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: github-credentials
+  - secretRef:
+      name: jira-credentials
+  - secretRef:
+      name: slack-credentials
+```
+
+### Security Notes
+
+- Credentials are scoped at the **executor deployment level**, not per-agent
+- If you need different credentials for different agents, deploy multiple executor instances
+- Use Kubernetes RBAC to control which service accounts can read which Secrets
+- Use fine-grained tokens (e.g., GitHub PATs with minimal scope) rather than broad credentials

--- a/executors/claude-agent-sdk/chart/templates/deployment.yaml
+++ b/executors/claude-agent-sdk/chart/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - secretRef:
                 name: otel-environment-variables
                 optional: true
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
           volumeMounts:

--- a/executors/claude-agent-sdk/chart/values.yaml
+++ b/executors/claude-agent-sdk/chart/values.yaml
@@ -29,6 +29,16 @@ app:
       memory: "1Gi"
       cpu: "1000m"
 
+# Additional environment variables from Kubernetes Secrets or ConfigMaps
+# Use this to inject credentials (GitHub tokens, API keys, etc.) into the executor
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: github-credentials
+#   - secretRef:
+#       name: jira-credentials
+extraEnvFrom: []
+
 # Service configuration
 service:
   name: executor-claude-agent-sdk

--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -113,7 +113,8 @@ class ClaudeAgentExecutor(BaseExecutor):
                 summary = ", ".join(f"{s.name} ({len(s.tools)} tools)" for s in mcp_servers if s.tools)
                 logger.info(f"Connecting {len(sdk_servers)} MCP servers: {summary}")
 
-        env: Dict[str, str] = {"ANTHROPIC_API_KEY": api_key}
+        env: Dict[str, str] = dict(os.environ)
+        env["ANTHROPIC_API_KEY"] = api_key
         if base_url:
             env["ANTHROPIC_BASE_URL"] = base_url
 


### PR DESCRIPTION
Add credential injection for Claude Agent SDK executor via Kubernetes Secrets using `extraEnvFrom` Helm configuration, enabling agents to authenticate with external tools like gh, git, and APIs.