### PR TITLE
fix(executors/claude-agent-sdk): pass Agent CRD prompt to Claude subprocess

### DIFF
--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -146,6 +146,14 @@ spec:
 
 The executor maps each MCPServer's resolved connection info (url, transport, headers) into the Claude Agent SDK's native `mcp_servers` option. Built-in tools (Read, Write, Edit, Bash, Grep, Glob) remain available.
 
+## Agent Prompt
+
+The `spec.prompt` field from the Agent CRD is passed to the Claude subprocess as appended system instructions. The SDK's built-in system prompt (tool instructions, safety guidelines) is preserved — the agent prompt is appended after it using the `claude_code` preset.
+
+If no prompt is set on the Agent CRD, the executor uses the SDK's default system prompt.
+
+Parameter templating (e.g., `{language}` replaced by a query parameter value) is resolved upstream by the ark-sdk before reaching the executor.
+
 ## Configuration
 
 Model name and API key are configured via the Model CRD (see [Prerequisites](#prerequisites)). The following environment variables are available for optional configuration:

--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -117,6 +117,11 @@ class ClaudeAgentExecutor(BaseExecutor):
         if base_url:
             env["ANTHROPIC_BASE_URL"] = base_url
 
+        prompt_kwargs: Dict = {}
+        agent_prompt = getattr(request.agent, "prompt", "") or ""
+        if agent_prompt:
+            prompt_kwargs["system_prompt"] = {"type": "preset", "preset": "claude_code", "append": agent_prompt}
+
         resume_kwargs: Dict = {}
         if previous_session_id:
             resume_kwargs["resume"] = previous_session_id
@@ -126,6 +131,7 @@ class ClaudeAgentExecutor(BaseExecutor):
             permission_mode="bypassPermissions",
             env=env,
             **mcp_kwargs,
+            **prompt_kwargs,
             **resume_kwargs,
         )
         logger.info(f"{'Resuming session ' + previous_session_id if previous_session_id else 'Starting new session'} for conversation {conversation_id}")

--- a/executors/claude-agent-sdk/tests/test_mcp_options.py
+++ b/executors/claude-agent-sdk/tests/test_mcp_options.py
@@ -1,4 +1,4 @@
-"""Tests for MCP server option mapping and Model CRD config in ClaudeAgentExecutor."""
+"""Tests for MCP server option mapping, Model CRD config, and agent prompt in ClaudeAgentExecutor."""
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -136,6 +136,7 @@ class TestExecuteAgentMcpIntegration:
         request.conversationId = "test-conv"
         request.userInput.content = "hello"
         request.agent.name = "test-agent"
+        request.agent.prompt = ""
         request.agent.model = _model_config()
         request.mcpServers = [
             _server(name="github-mcp", url="http://github:8080", headers={"Auth": "Bearer x"}, tools=["search"]),
@@ -177,6 +178,7 @@ class TestExecuteAgentMcpIntegration:
         request.conversationId = "test-conv-2"
         request.userInput.content = "hello"
         request.agent.name = "test-agent"
+        request.agent.prompt = ""
         request.agent.model = _model_config()
         request.mcpServers = []
 
@@ -207,3 +209,87 @@ class TestExecuteAgentMcpIntegration:
         opts = captured_options["options"]
         assert not hasattr(opts, "mcp_servers") or opts.mcp_servers is None
         assert not hasattr(opts, "allowed_tools") or opts.allowed_tools is None
+
+
+class TestExecuteAgentPrompt:
+    @pytest.mark.asyncio
+    async def test_prompt_passed_as_system_prompt_append(self, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+
+        request = MagicMock()
+        request.conversationId = "test-conv-prompt"
+        request.userInput.content = "hello"
+        request.agent.name = "test-agent"
+        request.agent.prompt = "You are a security auditor. Review code for vulnerabilities."
+        request.agent.model = _model_config()
+        request.mcpServers = []
+
+        captured_options = {}
+
+        class FakeClient:
+            def __init__(self, options=None):
+                captured_options["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                msg = MagicMock()
+                msg.result = "done"
+                yield msg
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(request)
+
+        opts = captured_options["options"]
+        assert opts.system_prompt == {
+            "type": "preset",
+            "preset": "claude_code",
+            "append": "You are a security auditor. Review code for vulnerabilities.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_prompt_no_system_prompt(self, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+
+        request = MagicMock()
+        request.conversationId = "test-conv-no-prompt"
+        request.userInput.content = "hello"
+        request.agent.name = "test-agent"
+        request.agent.prompt = ""
+        request.agent.model = _model_config()
+        request.mcpServers = []
+
+        captured_options = {}
+
+        class FakeClient:
+            def __init__(self, options=None):
+                captured_options["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                msg = MagicMock()
+                msg.result = "done"
+                yield msg
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(request)
+
+        opts = captured_options["options"]
+        assert not hasattr(opts, "system_prompt") or opts.system_prompt is None

--- a/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/design.md
+++ b/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/design.md
@@ -1,0 +1,50 @@
+# Design: Agent CRD Prompt Support for Claude Agent SDK Executor
+
+## Context
+
+The executor receives `request.agent.prompt` (already parameter-templated by the ark-sdk query extension) but ignores it. The Claude subprocess runs with the SDK's default minimal system prompt regardless of what's configured on the Agent CRD.
+
+The previous model-CRD-integration change explicitly deferred this as a non-goal because setting `system_prompt` as a plain string replaces the SDK's built-in prompt (which includes tool instructions). The SDK now supports a preset-with-append pattern that resolves this tension.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pass the Agent CRD's resolved prompt to the Claude subprocess as appended system instructions
+- Preserve the SDK's built-in system prompt (tool instructions, safety guidelines)
+- No behavior change when the agent has no prompt configured
+
+**Non-Goals:**
+- Using `description` — stays metadata-only, consistent with the built-in executor
+- Prompt changes on session resume — out of scope
+- Parameter templating in the executor — handled upstream by ark-sdk
+- Changes to ark-sdk or core operator
+
+## Decisions
+
+### Decision: Use preset-with-append for system prompt
+
+The Claude Agent SDK's `system_prompt` parameter on `ClaudeAgentOptions` accepts three forms:
+
+| Form | Effect |
+|------|--------|
+| `"custom string"` | Replaces the built-in prompt entirely |
+| `{"type": "preset", "preset": "claude_code"}` | Uses the full Claude Code prompt, no customization |
+| `{"type": "preset", "preset": "claude_code", "append": "..."}` | Full Claude Code prompt + custom text appended |
+
+**Chosen**: Preset-with-append. This preserves built-in tool instructions while injecting the agent's persona.
+
+**Alternative**: Plain string replacement. Rejected because losing tool instructions breaks built-in tool usage (Read, Write, Bash, etc.).
+
+### Decision: Only set system_prompt when prompt is non-empty
+
+When `request.agent.prompt` is empty (agent has no prompt configured), don't set `system_prompt` at all. This preserves current behavior exactly — the SDK uses its default minimal prompt.
+
+### Decision: No composition with description
+
+The `description` field is not included in the system prompt. In the built-in executor, description is used for team orchestration (selector agents, agent-as-tool) — not as system instructions. The Claude executor follows the same pattern.
+
+## Risks / Trade-offs
+
+**Prompt length** → Very long prompts appended to the Claude Code preset could approach context limits. Mitigation: This is the same risk as any system prompt — the SDK handles context management internally. No special handling needed.
+
+**Preset stability** → The `"claude_code"` preset content may change across SDK versions. Mitigation: This is desirable — agents get improvements to tool handling automatically.

--- a/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/proposal.md
+++ b/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/proposal.md
@@ -1,0 +1,53 @@
+# Agent CRD Prompt Support for Claude Agent SDK Executor
+
+## Problem
+
+The Claude Agent SDK executor ignores the `prompt` field from the Agent CRD. When a user configures an agent with a prompt (persona, role instructions, behavioral rules), that context never reaches the Claude subprocess — every agent executes with the SDK's default minimal system prompt regardless of its CRD configuration.
+
+The data is available: the ark-sdk query extension resolves the Agent CRD, templates parameters into the prompt, and delivers the result as `request.agent.prompt` in the `ExecutionEngineRequest`. The executor receives it but never uses it.
+
+The built-in completions executor handles this correctly — it resolves the prompt and prepends it as a system message to the conversation. The Claude executor needs parity.
+
+## Solution
+
+Pass `request.agent.prompt` to the Claude Agent SDK via `ClaudeAgentOptions.system_prompt` using the preset-with-append pattern:
+
+```python
+system_prompt={"type": "preset", "preset": "claude_code", "append": request.agent.prompt}
+```
+
+This preserves the SDK's built-in system prompt (tool instructions, safety guidelines) and appends the agent's custom prompt as additional instructions.
+
+### Behavior
+
+- **Prompt set on Agent CRD**: Built-in system prompt is preserved; agent prompt is appended via `system_prompt={"type": "preset", "preset": "claude_code", "append": prompt}`.
+- **No prompt on Agent CRD**: No `system_prompt` parameter is set — current default behavior, unchanged.
+- **Parameter templating**: Already handled upstream by the ark-sdk query extension (`_build_agent_config` resolves `{param}` placeholders before the executor sees the prompt).
+
+### Mapping
+
+```
+Agent CRD                    ark-sdk                         ClaudeAgentOptions
+──────────                   ───────                         ──────────────────
+spec.prompt: "You are..."  → request.agent.prompt: "You.."  → system_prompt.append: "You are..."
+spec.description: "..."    → request.agent.description       → (not used)
+```
+
+## Changes
+
+### Executor code (`executors/claude-agent-sdk/`)
+- `src/claude_agent_executor/executor.py` — Read `request.agent.prompt`; when non-empty, add `system_prompt={"type": "preset", "preset": "claude_code", "append": prompt}` to `ClaudeAgentOptions`.
+
+### Tests (`executors/claude-agent-sdk/`)
+- Update existing executor tests to verify `system_prompt` is set on `ClaudeAgentOptions` when `request.agent.prompt` is non-empty, and omitted when empty.
+
+### Documentation (`executors/claude-agent-sdk/`)
+- `README.md` — Document that the agent prompt is passed through to the Claude subprocess as appended system instructions.
+
+## Non-goals
+
+- Using the `description` field — stays metadata-only, consistent with the built-in executor where description is used for team orchestration and agent-as-tool, not system prompts.
+- Replacing the SDK's built-in system prompt — the preset-with-append pattern ensures built-in tool instructions are always present.
+- Prompt changes on session resume — the system prompt is set on `ClaudeAgentOptions` which applies to the session; resume behavior is out of scope.
+- Changes to the ark-sdk or core operator — all changes are in the marketplace executor.
+- Parameter templating in the executor — already handled upstream.

--- a/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/specs/claude-agent-execution/spec.md
+++ b/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/specs/claude-agent-execution/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Agent prompt passed as system instructions
+When `request.agent.prompt` is non-empty, the executor SHALL pass it to the Claude Agent SDK via `ClaudeAgentOptions.system_prompt` using the preset-with-append pattern, preserving the SDK's built-in system prompt.
+
+#### Scenario: Agent with prompt configured
+- **WHEN** a request arrives with `request.agent.prompt` set to `"You are a security auditor. Review code for vulnerabilities."`
+- **THEN** the executor SHALL set `system_prompt={"type": "preset", "preset": "claude_code", "append": "You are a security auditor. Review code for vulnerabilities."}` on `ClaudeAgentOptions`
+
+#### Scenario: Agent with no prompt configured
+- **WHEN** a request arrives with `request.agent.prompt` as an empty string
+- **THEN** the executor SHALL NOT set `system_prompt` on `ClaudeAgentOptions`, preserving the SDK's default behavior
+
+#### Scenario: Agent with parameterized prompt
+- **WHEN** an Agent CRD has `spec.prompt: "Analyze {language} code"` with parameter `language` resolved to `"Python"` by the ark-sdk
+- **THEN** `request.agent.prompt` SHALL already contain `"Analyze Python code"` and the executor SHALL pass it as-is via the preset-with-append pattern

--- a/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/tasks.md
+++ b/openspec/changes/archive/2026-04-16-claude-executor-agent-prompt/tasks.md
@@ -1,0 +1,13 @@
+## 1. Core Implementation
+
+- [x] 1.1 In `executor.py`, read `request.agent.prompt` and when non-empty, add `system_prompt={"type": "preset", "preset": "claude_code", "append": prompt}` to `ClaudeAgentOptions`
+
+## 2. Tests
+
+- [x] 2.1 Add test: when `request.agent.prompt` is non-empty, `ClaudeAgentOptions` is constructed with the correct `system_prompt` preset-with-append config
+- [x] 2.2 Add test: when `request.agent.prompt` is empty, `ClaudeAgentOptions` has no `system_prompt` set
+- [x] 2.3 Fix existing integration tests in `test_mcp_options.py` to explicitly set `request.agent.prompt = ""` so MagicMock doesn't return a truthy mock object for the prompt field
+
+## 3. Documentation
+
+- [x] 3.1 Update `README.md` to document that the Agent CRD prompt is passed through as appended system instructions

--- a/openspec/specs/claude-agent-execution/spec.md
+++ b/openspec/specs/claude-agent-execution/spec.md
@@ -64,6 +64,21 @@ The executor SHALL extend `BaseExecutor` from `ark-sdk` and be served via `Execu
 - **WHEN** a GET request is made to `/health`
 - **THEN** the executor SHALL respond with HTTP 200
 
+### Requirement: Agent prompt passed as system instructions
+When `request.agent.prompt` is non-empty, the executor SHALL pass it to the Claude Agent SDK via `ClaudeAgentOptions.system_prompt` using the preset-with-append pattern, preserving the SDK's built-in system prompt.
+
+#### Scenario: Agent with prompt configured
+- **WHEN** a request arrives with `request.agent.prompt` set to `"You are a security auditor. Review code for vulnerabilities."`
+- **THEN** the executor SHALL set `system_prompt={"type": "preset", "preset": "claude_code", "append": "You are a security auditor. Review code for vulnerabilities."}` on `ClaudeAgentOptions`
+
+#### Scenario: Agent with no prompt configured
+- **WHEN** a request arrives with `request.agent.prompt` as an empty string
+- **THEN** the executor SHALL NOT set `system_prompt` on `ClaudeAgentOptions`, preserving the SDK's default behavior
+
+#### Scenario: Agent with parameterized prompt
+- **WHEN** an Agent CRD has `spec.prompt: "Analyze {language} code"` with parameter `language` resolved to `"Python"` by the ark-sdk
+- **THEN** `request.agent.prompt` SHALL already contain `"Analyze Python code"` and the executor SHALL pass it as-is via the preset-with-append pattern
+
 ### Requirement: ExecutionEngine CRD registration
 The Helm chart SHALL create an `ExecutionEngine` custom resource (apiVersion: `ark.mckinsey.com/v1prealpha1`) that references the executor's K8s Service, enabling ARK to discover and route to this executor.
 


### PR DESCRIPTION
## Summary

- The Claude executor was ignoring `spec.prompt` from the Agent CRD — every agent ran with the SDK's default minimal system prompt regardless of configuration
- Pass `request.agent.prompt` to `ClaudeAgentOptions.system_prompt` using the preset-with-append pattern, preserving built-in tool instructions while injecting the agent's persona
- When no prompt is configured, behavior is unchanged (SDK default)
- Fix existing integration tests to explicitly set `request.agent.prompt = ""` to avoid MagicMock returning truthy mock objects
- Add openspec change archive with proposal, design, specs, and tasks

## Test plan

- [ ] Verify agent with `spec.prompt` set receives the prompt as appended system instructions
- [ ] Verify agent without `spec.prompt` behaves identically to before (SDK default)
- [ ] Verify existing MCP and model config tests still pass
- [ ] Run `pytest tests/test_mcp_options.py` for the new `TestExecuteAgentPrompt` tests