### PR TITLE
fix(openai-responses): add Azure OpenAI provider support

### DIFF
--- a/executors/openai-responses/src/openai_responses_executor/executor.py
+++ b/executors/openai-responses/src/openai_responses_executor/executor.py
@@ -6,7 +6,7 @@ import os
 from typing import Any, Optional
 
 from ark_sdk.executor import BaseExecutor, ExecutionEngineRequest, Message
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, AsyncAzureOpenAI
 
 from .config import config
 from .models import FunctionTool, ModelConfig, ResponsesCreateParams, resolve_built_in_tools, resolve_reasoning, resolve_output_schema
@@ -95,10 +95,17 @@ class OpenAIResponsesExecutor(BaseExecutor):
             f"{'resuming' if previous_response_id else 'new session'})"
         )
 
-        client = AsyncOpenAI(
-            api_key=model_config.api_key,
-            **({"base_url": model_config.base_url} if model_config.base_url else {}),
-        )
+        if model_config.provider == "azure":
+            client = AsyncAzureOpenAI(
+                api_key=model_config.api_key,
+                azure_endpoint=model_config.base_url or "",
+                api_version=model_config.api_version or "2024-12-01-preview",
+            )
+        else:
+            client = AsyncOpenAI(
+                api_key=model_config.api_key,
+                **({"base_url": model_config.base_url} if model_config.base_url else {}),
+            )
 
         if previous_response_id:
             params = ResponsesCreateParams.continuation(
@@ -139,7 +146,14 @@ class OpenAIResponsesExecutor(BaseExecutor):
         for iteration in range(config.max_tool_iterations):
             api_kwargs = params.to_api_kwargs()
             logger.info(f"Request tools: {api_kwargs.get('tools')}")
-            response = await client.responses.create(**api_kwargs)
+
+            response = None
+            async with client.responses.stream(**api_kwargs) as stream:
+                async for event in stream:
+                    if event.type == "response.output_text.delta":
+                        await self.stream_chunk(event.delta)
+                response = await stream.get_final_response()
+
             self._save_response_id(conversation_id, response.id)
             logger.info(f"Response output types: {[getattr(item, 'type', None) for item in response.output]}")
 

--- a/executors/openai-responses/src/openai_responses_executor/executor.py
+++ b/executors/openai-responses/src/openai_responses_executor/executor.py
@@ -96,10 +96,14 @@ class OpenAIResponsesExecutor(BaseExecutor):
         )
 
         if model_config.provider == "azure":
+            if not model_config.base_url:
+                raise ValueError("Model CRD azure config must include a baseUrl")
+            if not model_config.api_version:
+                raise ValueError("Model CRD azure config must include an apiVersion")
             client = AsyncAzureOpenAI(
                 api_key=model_config.api_key,
-                azure_endpoint=model_config.base_url or "",
-                api_version=model_config.api_version or "2024-12-01-preview",
+                azure_endpoint=model_config.base_url,
+                api_version=model_config.api_version,
             )
         else:
             client = AsyncOpenAI(

--- a/executors/openai-responses/src/openai_responses_executor/executor.py
+++ b/executors/openai-responses/src/openai_responses_executor/executor.py
@@ -96,10 +96,6 @@ class OpenAIResponsesExecutor(BaseExecutor):
         )
 
         if model_config.provider == "azure":
-            if not model_config.base_url:
-                raise ValueError("Model CRD azure config must include a baseUrl")
-            if not model_config.api_version:
-                raise ValueError("Model CRD azure config must include an apiVersion")
             client = AsyncAzureOpenAI(
                 api_key=model_config.api_key,
                 azure_endpoint=model_config.base_url,

--- a/executors/openai-responses/src/openai_responses_executor/executor.py
+++ b/executors/openai-responses/src/openai_responses_executor/executor.py
@@ -6,7 +6,6 @@ import os
 from typing import Any, Optional
 
 from ark_sdk.executor import BaseExecutor, ExecutionEngineRequest, Message
-from openai import AsyncOpenAI, AsyncAzureOpenAI
 
 from .config import config
 from .models import FunctionTool, ModelConfig, ResponsesCreateParams, resolve_built_in_tools, resolve_reasoning, resolve_output_schema
@@ -95,17 +94,7 @@ class OpenAIResponsesExecutor(BaseExecutor):
             f"{'resuming' if previous_response_id else 'new session'})"
         )
 
-        if model_config.provider == "azure":
-            client = AsyncAzureOpenAI(
-                api_key=model_config.api_key,
-                azure_endpoint=model_config.base_url,
-                api_version=model_config.api_version,
-            )
-        else:
-            client = AsyncOpenAI(
-                api_key=model_config.api_key,
-                **({"base_url": model_config.base_url} if model_config.base_url else {}),
-            )
+        client = model_config.build_client()
 
         if previous_response_id:
             params = ResponsesCreateParams.continuation(

--- a/executors/openai-responses/src/openai_responses_executor/models.py
+++ b/executors/openai-responses/src/openai_responses_executor/models.py
@@ -25,7 +25,9 @@ class ModelConfig(BaseModel):
 
     model_name: str
     api_key: str
+    provider: str = "openai"
     base_url: Optional[str] = None
+    api_version: Optional[str] = None
 
     @classmethod
     def from_request(cls, request: ExecutionEngineRequest) -> "ModelConfig":
@@ -34,19 +36,33 @@ class ModelConfig(BaseModel):
             raise ValueError("Agent must have a model configured via Model CRD")
 
         config = getattr(model, "config", None) or {}
+        provider = getattr(model, "type", "openai") or "openai"
+
+        if provider == "azure":
+            azure_config = config.get("azure") or {}
+            api_key = azure_config.get("apiKey")
+            if not api_key:
+                raise ValueError("Model CRD azure config must include an apiKey")
+            return cls(
+                model_name=model.name,
+                api_key=api_key,
+                provider="azure",
+                base_url=azure_config.get("baseUrl") or None,
+                api_version=azure_config.get("apiVersion") or None,
+            )
+
         openai_config = config.get("openai")
         if not openai_config:
             raise ValueError(
-                "Agent model must have provider 'openai' with apiKey configured via Model CRD"
+                "Agent model must have provider 'openai' or 'azure' with apiKey configured via Model CRD"
             )
-
         api_key = openai_config.get("apiKey")
         if not api_key:
             raise ValueError("Model CRD openai config must include an apiKey")
-
         return cls(
             model_name=model.name,
             api_key=api_key,
+            provider="openai",
             base_url=openai_config.get("baseUrl") or None,
         )
 

--- a/executors/openai-responses/src/openai_responses_executor/models.py
+++ b/executors/openai-responses/src/openai_responses_executor/models.py
@@ -20,9 +20,18 @@ OUTPUT_SCHEMA_ANNOTATION_KEY = "executor-openai-responses.ark.mckinsey.com/outpu
 # ---------------------------------------------------------------------------
 
 
-class ModelConfig(BaseModel):
-    """OpenAI credentials and model name extracted from the Model CRD."""
+class AzureModelConfig(BaseModel):
+    apiKey: str
+    baseUrl: str
+    apiVersion: str
 
+
+class OpenAIModelConfig(BaseModel):
+    apiKey: str
+    baseUrl: Optional[str] = None
+
+
+class ModelConfig(BaseModel):
     model_name: str
     api_key: str
     provider: str = "openai"
@@ -39,38 +48,11 @@ class ModelConfig(BaseModel):
         provider = getattr(model, "type", "openai") or "openai"
 
         if provider == "azure":
-            azure_config = config.get("azure") or {}
-            api_key = azure_config.get("apiKey")
-            if not api_key:
-                raise ValueError("Model CRD azure config must include an apiKey")
-            base_url = azure_config.get("baseUrl")
-            if not base_url:
-                raise ValueError("Model CRD azure config must include a baseUrl")
-            api_version = azure_config.get("apiVersion")
-            if not api_version:
-                raise ValueError("Model CRD azure config must include an apiVersion")
-            return cls(
-                model_name=model.name,
-                api_key=api_key,
-                provider="azure",
-                base_url=base_url,
-                api_version=api_version,
-            )
+            azure = AzureModelConfig.model_validate(config.get("azure") or {})
+            return cls(model_name=model.name, api_key=azure.apiKey, provider="azure", base_url=azure.baseUrl, api_version=azure.apiVersion)
 
-        openai_config = config.get("openai")
-        if not openai_config:
-            raise ValueError(
-                "Agent model must have provider 'openai' or 'azure' with apiKey configured via Model CRD"
-            )
-        api_key = openai_config.get("apiKey")
-        if not api_key:
-            raise ValueError("Model CRD openai config must include an apiKey")
-        return cls(
-            model_name=model.name,
-            api_key=api_key,
-            provider="openai",
-            base_url=openai_config.get("baseUrl") or None,
-        )
+        openai = OpenAIModelConfig.model_validate(config.get("openai") or {})
+        return cls(model_name=model.name, api_key=openai.apiKey, provider="openai", base_url=openai.baseUrl)
 
 
 # ---------------------------------------------------------------------------

--- a/executors/openai-responses/src/openai_responses_executor/models.py
+++ b/executors/openai-responses/src/openai_responses_executor/models.py
@@ -2,10 +2,13 @@
 
 import json
 import logging
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from pydantic import BaseModel
 
 from ark_sdk.executor import ExecutionEngineRequest
+
+if TYPE_CHECKING:
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,19 @@ class ModelConfig(BaseModel):
     provider: str = "openai"
     base_url: Optional[str] = None
     api_version: Optional[str] = None
+
+    def build_client(self) -> "Union[AsyncOpenAI, AsyncAzureOpenAI]":
+        from openai import AsyncAzureOpenAI, AsyncOpenAI
+        if self.provider == "azure":
+            return AsyncAzureOpenAI(
+                api_key=self.api_key,
+                azure_endpoint=self.base_url,
+                api_version=self.api_version,
+            )
+        return AsyncOpenAI(
+            api_key=self.api_key,
+            **({"base_url": self.base_url} if self.base_url else {}),
+        )
 
     @classmethod
     def from_request(cls, request: ExecutionEngineRequest) -> "ModelConfig":

--- a/executors/openai-responses/src/openai_responses_executor/models.py
+++ b/executors/openai-responses/src/openai_responses_executor/models.py
@@ -43,12 +43,18 @@ class ModelConfig(BaseModel):
             api_key = azure_config.get("apiKey")
             if not api_key:
                 raise ValueError("Model CRD azure config must include an apiKey")
+            base_url = azure_config.get("baseUrl")
+            if not base_url:
+                raise ValueError("Model CRD azure config must include a baseUrl")
+            api_version = azure_config.get("apiVersion")
+            if not api_version:
+                raise ValueError("Model CRD azure config must include an apiVersion")
             return cls(
                 model_name=model.name,
                 api_key=api_key,
                 provider="azure",
-                base_url=azure_config.get("baseUrl") or None,
-                api_version=azure_config.get("apiVersion") or None,
+                base_url=base_url,
+                api_version=api_version,
             )
 
         openai_config = config.get("openai")

--- a/executors/openai-responses/tests/test_model_config.py
+++ b/executors/openai-responses/tests/test_model_config.py
@@ -1,0 +1,116 @@
+"""Tests for ModelConfig Pydantic validation."""
+
+import pytest
+from pydantic import ValidationError
+from unittest.mock import MagicMock
+
+from openai_responses_executor.models import AzureModelConfig, OpenAIModelConfig, ModelConfig
+
+
+def _model(name="gpt-5", provider="openai", config=None):
+    m = MagicMock()
+    m.name = name
+    m.type = provider
+    m.config = config or {}
+    return m
+
+
+def _request(model):
+    req = MagicMock()
+    req.agent.model = model
+    return req
+
+
+class TestAzureModelConfig:
+    def test_valid(self):
+        cfg = AzureModelConfig(apiKey="key", baseUrl="https://example.com", apiVersion="2024-04-01-preview")
+        assert cfg.apiKey == "key"
+        assert cfg.baseUrl == "https://example.com"
+        assert cfg.apiVersion == "2024-04-01-preview"
+
+    def test_missing_api_key(self):
+        with pytest.raises(ValidationError, match="apiKey"):
+            AzureModelConfig(baseUrl="https://example.com", apiVersion="2024-04-01-preview")
+
+    def test_missing_base_url(self):
+        with pytest.raises(ValidationError, match="baseUrl"):
+            AzureModelConfig(apiKey="key", apiVersion="2024-04-01-preview")
+
+    def test_missing_api_version(self):
+        with pytest.raises(ValidationError, match="apiVersion"):
+            AzureModelConfig(apiKey="key", baseUrl="https://example.com")
+
+
+class TestOpenAIModelConfig:
+    def test_valid_with_base_url(self):
+        cfg = OpenAIModelConfig(apiKey="sk-test", baseUrl="https://proxy.example.com")
+        assert cfg.baseUrl == "https://proxy.example.com"
+
+    def test_valid_without_base_url(self):
+        cfg = OpenAIModelConfig(apiKey="sk-test")
+        assert cfg.baseUrl is None
+
+    def test_missing_api_key(self):
+        with pytest.raises(ValidationError, match="apiKey"):
+            OpenAIModelConfig(baseUrl="https://proxy.example.com")
+
+
+class TestModelConfigFromRequest:
+    def test_azure_provider(self):
+        model = _model("gpt-5", "azure", {
+            "azure": {"apiKey": "key", "baseUrl": "https://azure.example.com", "apiVersion": "2024-04-01-preview"}
+        })
+        mc = ModelConfig.from_request(_request(model))
+        assert mc.provider == "azure"
+        assert mc.api_key == "key"
+        assert mc.base_url == "https://azure.example.com"
+        assert mc.api_version == "2024-04-01-preview"
+
+    def test_openai_provider(self):
+        model = _model("gpt-5", "openai", {"openai": {"apiKey": "sk-test"}})
+        mc = ModelConfig.from_request(_request(model))
+        assert mc.provider == "openai"
+        assert mc.api_key == "sk-test"
+        assert mc.base_url is None
+
+    def test_openai_with_base_url(self):
+        model = _model("gpt-5", "openai", {"openai": {"apiKey": "sk-test", "baseUrl": "https://proxy.example.com"}})
+        mc = ModelConfig.from_request(_request(model))
+        assert mc.base_url == "https://proxy.example.com"
+
+    def test_azure_missing_base_url_raises(self):
+        model = _model("gpt-5", "azure", {
+            "azure": {"apiKey": "key", "apiVersion": "2024-04-01-preview"}
+        })
+        with pytest.raises(ValidationError, match="baseUrl"):
+            ModelConfig.from_request(_request(model))
+
+    def test_azure_missing_api_version_raises(self):
+        model = _model("gpt-5", "azure", {
+            "azure": {"apiKey": "key", "baseUrl": "https://azure.example.com"}
+        })
+        with pytest.raises(ValidationError, match="apiVersion"):
+            ModelConfig.from_request(_request(model))
+
+    def test_azure_missing_api_key_raises(self):
+        model = _model("gpt-5", "azure", {
+            "azure": {"baseUrl": "https://azure.example.com", "apiVersion": "2024-04-01-preview"}
+        })
+        with pytest.raises(ValidationError, match="apiKey"):
+            ModelConfig.from_request(_request(model))
+
+    def test_openai_missing_api_key_raises(self):
+        model = _model("gpt-5", "openai", {"openai": {"baseUrl": "https://proxy.example.com"}})
+        with pytest.raises(ValidationError, match="apiKey"):
+            ModelConfig.from_request(_request(model))
+
+    def test_no_model_raises(self):
+        req = MagicMock()
+        req.agent.model = None
+        with pytest.raises(ValueError, match="model"):
+            ModelConfig.from_request(req)
+
+    def test_unknown_provider_falls_back_to_openai_path(self):
+        model = _model("gpt-5", "unknown", {})
+        with pytest.raises(ValidationError):
+            ModelConfig.from_request(_request(model))


### PR DESCRIPTION
## Summary
- `ModelConfig.from_request()` now handles `provider: azure` — reads `azure` config block for `apiKey`, `baseUrl`, `apiVersion`
- Executor creates `AsyncAzureOpenAI` when provider is azure, `AsyncOpenAI` otherwise
- Fixes the issue reported by users on Azure AKS + AI Foundry deployments