### PR TITLE
feat(demos): add onboarding-guide-bundle

### DIFF
--- a/demos/onboarding-guide-bundle/CHANGELOG.md
+++ b/demos/onboarding-guide-bundle/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release.
+- Five-agent Argo workflow that generates `analysis.md`, `ONBOARDING.md`, and `TICKET.md` from any public git URL.
+- Uses the Claude Agent SDK executor (git clone + ticket proposal), the OpenAI Responses executor (web search), and the default completions executor (analysis + writing via file-gateway MCP).
+- Per-run `output/<workflow-name>/` folders on file-gateway so runs don't overwrite each other.
+- `fetch-output.sh` defaults to the latest workflow.
+- RBAC + ServiceAccount for Argo Workflows to create `Query` CRs.

--- a/demos/onboarding-guide-bundle/Makefile
+++ b/demos/onboarding-guide-bundle/Makefile
@@ -1,0 +1,89 @@
+.PHONY: help build install install-with-argo uninstall onboarding-demo fetch-output clean
+
+NAMESPACE ?= default
+RELEASE_NAME ?= onboarding-guide-bundle
+CHART_DIR ?= chart
+# Set to true to skip installing file-gateway and use the one already in the namespace.
+USE_EXISTING_FILE_GATEWAY ?= false
+# Set to 1 to skip `helm dependency build` (run once manually first if it hangs).
+SKIP_DEP_BUILD ?= 0
+
+FILE_GATEWAY_SKIP_FLAGS := \
+	--set file-gateway.enabled=false \
+	--set file-gateway.fileApi.enabled=false \
+	--set file-gateway.filesystemMcp.enabled=false \
+	--set file-gateway.versitygw.enabled=false \
+	--set file-gateway.versitygw.createSecret=false \
+	--set file-gateway.storage.enabled=false \
+	--set file-gateway.httpRoute.enabled=false
+
+ifeq ($(USE_EXISTING_FILE_GATEWAY),true)
+FILE_GATEWAY_SKIP := $(FILE_GATEWAY_SKIP_FLAGS)
+else
+FILE_GATEWAY_SKIP :=
+endif
+
+help:
+	@echo "Onboarding Guide Demo Bundle"
+	@echo ""
+	@echo "Namespace: $(NAMESPACE) (override with NAMESPACE=my-ns)"
+	@echo ""
+	@echo "Required steps (prerequisites: 'default' and 'responses' Models must exist in"
+	@echo "the target namespace, and Claude Agent SDK + OpenAI Responses executors must"
+	@echo "be installed via 'ark install marketplace/executors/...'):"
+	@echo ""
+	@echo "  export ANTHROPIC_API_KEY=..."
+	@echo "  make uninstall             Remove bundle (and file-gateway, unless shared)"
+	@echo "  make build                 helm dependency build"
+	@echo "  make install-with-argo     Install bundle + file-gateway + WorkflowTemplate"
+	@echo "  make onboarding-demo REPO_URL=https://github.com/<owner>/<repo>"
+	@echo "                             Run the onboarding-generate workflow"
+	@echo "  make fetch-output WF=<workflow-name>"
+	@echo "                             Download analysis.md / ONBOARDING.md / TICKET.md"
+	@echo ""
+	@echo "Options:"
+	@echo "  USE_EXISTING_FILE_GATEWAY=true   reuse an existing file-gateway in the namespace"
+	@echo "  SKIP_DEP_BUILD=1                skip 'helm dependency build' (pre-built charts)"
+
+build:
+ifneq ($(SKIP_DEP_BUILD),1)
+	helm dependency build $(CHART_DIR)
+else
+	@echo "skipping helm dependency build (SKIP_DEP_BUILD=1)"
+endif
+
+install: build
+	@test -n "$$ANTHROPIC_API_KEY" || (echo "ERROR: export ANTHROPIC_API_KEY=... before installing"; exit 1)
+	helm upgrade --install $(RELEASE_NAME) $(CHART_DIR) \
+		--namespace $(NAMESPACE) --create-namespace \
+		--set anthropic.apiKey="$$ANTHROPIC_API_KEY" \
+		$(FILE_GATEWAY_SKIP)
+
+install-with-argo: install
+	@echo "Bundle installed. The WorkflowTemplate 'onboarding-generate' is ready."
+	@echo "Kick off a run with: make onboarding-demo REPO_URL=https://github.com/<owner>/<repo>"
+
+uninstall:
+	-helm uninstall $(RELEASE_NAME) --namespace $(NAMESPACE)
+
+onboarding-demo:
+	@test -n "$(REPO_URL)" || (echo "ERROR: pass REPO_URL=https://github.com/<owner>/<repo>"; exit 1)
+	kubectl -n $(NAMESPACE) create -f - <<EOF
+	apiVersion: argoproj.io/v1alpha1
+	kind: Workflow
+	metadata:
+	  generateName: onboarding-
+	spec:
+	  workflowTemplateRef:
+	    name: onboarding-generate
+	  arguments:
+	    parameters:
+	      - name: repo-url
+	        value: $(REPO_URL)
+	EOF
+
+fetch-output:
+	@test -n "$(WF)" || (echo "ERROR: pass WF=<workflow-name> (e.g. WF=onboarding-xyz)"; exit 1)
+	./scripts/fetch-output.sh $(WF) $(NAMESPACE)
+
+clean: uninstall

--- a/demos/onboarding-guide-bundle/README.md
+++ b/demos/onboarding-guide-bundle/README.md
@@ -1,0 +1,141 @@
+# Onboarding Guide Bundle
+
+An Argo workflow that turns **any public git URL** into three artifacts a new joiner actually needs: a structural `analysis.md`, a new-joiner `ONBOARDING.md`, and a `TICKET.md` proposing a good first issue. The demo spans three execution engines — **Claude Agent SDK** at both ends (clone + ticket), **OpenAI Responses** in the middle (live web research), and the built-in completions executor for analysis + writing.
+
+## What's included
+
+**5 agents** wired to three execution engines:
+
+| Agent | Execution engine | Model | What it does |
+|---|---|---|---|
+| `repo-reader-claude-sdk` | Claude Agent SDK | Claude Haiku (`anthropic`) | `git clone --depth 1` the URL into its sandbox; return the stack hint, file tree, and full contents of every source file as text |
+| `code-analyzer-completions` | default completions (+ filesystem MCP) | `default` | consumes `repo-reader`'s dump via `prev-query`, produces the structural analysis, AND writes it to `output/<workflow-name>/analysis.md` |
+| `research-buddy-openai-responses` | OpenAI Responses (+ `web_search_preview`) | `responses` | takes the stack hint, searches the live web for docs / quickstarts / pitfalls |
+| `onboarding-writer-completions` | default completions (+ filesystem MCP) | `default` | synthesises the analysis + research and writes `output/<workflow-name>/ONBOARDING.md` |
+| `ticket-suggester-claude-sdk` | Claude Agent SDK | Claude Haiku (`anthropic`) | proposes a good-first-ticket from the analysis; a small non-agent Argo step (`write-ticket`) uploads the result to `output/<workflow-name>/TICKET.md` |
+
+Plus the supporting chart resources:
+
+- **`file-gateway`** (Helm dependency — provides filesystem MCP for writes + HTTP API for downloads)
+- **Argo Workflow RBAC** (ServiceAccount + Role + RoleBinding so the workflow can create `Query` CRs)
+- **`MCPServer/mcp-filesystem`** CR pointing at `file-gateway-filesystem-mcp`
+- **Anthropic `Model` CR** and a Secret created from `anthropic.apiKey`
+- **`WorkflowTemplate/onboarding-generate`** (Argo) with the five-step DAG
+
+## Prerequisites
+
+- Ark cluster with the default completions executor ready.
+- Argo Workflows installed.
+- The two marketplace executors installed (this bundle does not install them):
+  ```bash
+  ark install marketplace/executors/executor-openai-responses --marketplace-version 0.1.3 -y
+  ark install marketplace/executors/executor-claude-agent-sdk -y
+  ```
+  Pin `executor-openai-responses` to `0.1.3` — `0.1.4` ships a broken build (see the marketplace issue tracker).
+- **Models already in the target namespace:**
+  - `default` — any completions-compatible Model (the Ark cluster default).
+  - `responses` — OpenAI Responses-compatible Model (provider: `openai`).
+  - (The chart creates the third one, `anthropic`, from `anthropic.apiKey` or an existing Secret.)
+- An **Anthropic API key** for the Claude Agent SDK agents.
+
+## Install
+
+Install in any namespace (default if omitted). If file-gateway is already present in the namespace (for example from another demo bundle), set `USE_EXISTING_FILE_GATEWAY=true` to skip installing it.
+
+```bash
+cd agents-at-scale-marketplace/demos/onboarding-guide-bundle
+export ANTHROPIC_API_KEY=...
+make build
+make install-with-argo
+```
+
+To pin against a pre-existing `anthropic-api-key` Secret instead of passing the key at install time, install with:
+
+```bash
+helm upgrade --install onboarding-guide-bundle chart \
+  --namespace default \
+  --set anthropic.existingSecretName=my-existing-secret
+```
+
+## Run the workflow
+
+From the Ark dashboard: open **Workflow Templates**, pick `onboarding-generate`, click Run, and fill in the `repo-url` parameter.
+
+From the CLI:
+
+```bash
+make onboarding-demo REPO_URL=https://github.com/karpathy/micrograd
+```
+
+or directly:
+
+```bash
+kubectl create -f - <<'EOF'
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: onboarding-
+spec:
+  workflowTemplateRef:
+    name: onboarding-generate
+  arguments:
+    parameters:
+      - name: repo-url
+        value: https://github.com/<owner>/<repo>
+EOF
+```
+
+## Fetch the output
+
+Each run writes to its own `output/<workflow-name>/` folder on file-gateway. Pull both the analysis and the onboarding guide to your laptop:
+
+```bash
+make fetch-output WF=<workflow-name>        # or: ./scripts/fetch-output.sh <workflow-name>
+./scripts/fetch-output.sh                   # no arg = latest run
+open ./output/<workflow-name>/ONBOARDING.md
+```
+
+## Uninstall
+
+```bash
+make uninstall
+```
+
+## DAG at a glance
+
+```
+         ┌─────────────────────────────────────────┐
+         │ repo-reader-claude-sdk (Claude Agent SDK)│
+         │ git clone + read → text dump             │
+         └──────┬──────────────────────────────────┘
+                │
+       ┌────────┴────────┐
+       ▼                 ▼
+┌─────────────────┐  ┌────────────────────────────────┐
+│ code-analyzer-   │  │ research-buddy-openai-responses│
+│ completions      │  │ (OpenAI Responses + web search)│
+│ writes analysis  │  │                                │
+└──────┬───────────┘  └───────────────┬────────────────┘
+       └─────────────┬────────────────┘
+                     ▼
+         ┌───────────────────────────────┐
+         │ onboarding-writer-completions │
+         │ writes ONBOARDING.md          │
+         └──────────┬────────────────────┘
+                    ▼
+         ┌───────────────────────────────┐
+         │ ticket-suggester-claude-sdk   │
+         │ (Claude Agent SDK)            │
+         └──────────┬────────────────────┘
+                    ▼
+         ┌───────────────────────────────┐
+         │ write-ticket (Argo script)    │
+         │ uploads TICKET.md             │
+         └───────────────────────────────┘
+```
+
+## Notes
+
+- **Why two executors for Claude work?** Claude Agent SDK runs Claude Code's bundled toolchain (Bash / Read / Glob) inside its own pod sandbox, so it can `git clone` and read arbitrary files — but it cannot reach the cluster-side filesystem MCP. The default completions executor *can* reach it but lacks a shell. This bundle uses both: Claude Agent SDK for fetching and for ticket suggestion, and the default executor (with Claude Haiku via the Anthropic `Model`) for the analysis/writing steps that need MCP.
+- **Why an extra `write-ticket` step?** `ticket-suggester-claude-sdk` returns its proposal as text. A small alpine + kubectl + curl Argo step reads the Query response and POSTs it to file-gateway so it lands alongside the other artifacts.
+- **Output folder per run:** `output/<workflow-name>/` is derived from `{{workflow.name}}` at run time. Runs do not overwrite each other.

--- a/demos/onboarding-guide-bundle/chart/.gitignore
+++ b/demos/onboarding-guide-bundle/chart/.gitignore
@@ -1,0 +1,2 @@
+charts/
+Chart.lock

--- a/demos/onboarding-guide-bundle/chart/.helmignore
+++ b/demos/onboarding-guide-bundle/chart/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+*.sublime-project
+*.sublime-workspace

--- a/demos/onboarding-guide-bundle/chart/Chart.yaml
+++ b/demos/onboarding-guide-bundle/chart/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: onboarding-guide-bundle
+description: >-
+  Repo onboarding demo: given a public git URL, a 5-agent Argo workflow clones
+  the repo, analyses it, researches its stack on the live web, writes an
+  ONBOARDING.md, and proposes a good-first-ticket. Uses the Claude Agent SDK
+  executor (for git clone and ticket suggestion), the OpenAI Responses executor
+  (for live web search), and the default completions executor (for analysis +
+  writing, with filesystem MCP).
+version: 0.1.0
+type: application
+keywords:
+  - ark
+  - ai-agents
+  - demo
+  - onboarding
+  - multi-agent
+  - claude-agent-sdk
+  - openai-responses
+home: https://github.com/mckinsey/agents-at-scale
+sources:
+  - https://github.com/mckinsey/agents-at-scale-marketplace
+maintainers:
+  - name: ARK Team
+    email: ark-team@mckinsey.com
+annotations:
+  ark.mckinsey.com/category: demo
+  ark.mckinsey.com/type: bundle
+  ark.mckinsey.com/use-case: repo-onboarding
+  ark.mckinsey.com/components: agents,workflow
+dependencies:
+  - name: file-gateway
+    version: 0.1.6
+    repository: oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts
+    condition: file-gateway.enabled

--- a/demos/onboarding-guide-bundle/chart/templates/_helpers.tpl
+++ b/demos/onboarding-guide-bundle/chart/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- /*
+Common labels and annotations helpers.
+*/}}
+
+{{- define "onboarding.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "onboarding.anthropicSecretName" -}}
+{{- if .Values.anthropic.existingSecretName -}}
+{{ .Values.anthropic.existingSecretName }}
+{{- else -}}
+{{ .Values.anthropic.secretName }}
+{{- end -}}
+{{- end }}

--- a/demos/onboarding-guide-bundle/chart/templates/agents.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/agents.yaml
@@ -1,0 +1,242 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: repo-reader-claude-sdk
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  description: Clones a public git repository and returns its file tree and contents
+  executionEngine:
+    name: {{ .Values.executionEngines.claudeAgentSdk.name }}
+  modelRef:
+    name: {{ .Values.models.anthropic.name }}
+  prompt: |
+    You are a repo-ingest agent. Your job is to clone a public git repository and
+    return its source contents so downstream agents can analyse it.
+
+    Given a repository URL in the user input:
+
+    1. Use Bash to `git clone --depth 1 <URL> /tmp/repo` into your sandbox.
+       If the directory already exists, delete it first (`rm -rf /tmp/repo`).
+    2. Use Bash / Glob / LS to list every file under `/tmp/repo`. Exclude:
+       - `.git/`, virtualenvs (`venv/`, `.venv/`, `env/`)
+       - `node_modules/`, `__pycache__/`, `dist/`, `build/`, `target/`
+       - Binary files: images (`.png`, `.jpg`, `.svg`, ...), `.ipynb`, `.pdf`,
+         compiled artifacts
+    3. For every remaining file, use Read to load its full contents.
+    4. Return a single text response with three sections, in this exact order:
+
+       ```
+       STACK HINT: <one line, e.g. "Python, FastAPI, Pydantic (from requirements.txt, *.py)">
+
+       FILE TREE:
+       <one path per line, relative to repo root>
+
+       FILES:
+       === <relative/path/to/file> ===
+       <full file contents>
+
+       === <next/file> ===
+       <full file contents>
+       ...
+       ```
+
+    Do not summarise, interpret, or analyse — just return the raw contents.
+    If a file is over ~2,000 lines, truncate with a clear marker and continue.
+    Do not ask the user clarifying questions — always proceed with the URL given.
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: code-analyzer-completions
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  description: Deeply analyses a repository's structure, stack, and conventions
+  modelRef:
+    name: {{ .Values.models.default.name }}
+  prompt: |
+    You are a senior engineer analysing an unfamiliar codebase. You will be given
+    the full contents of a public git repository — a stack hint, a file tree, and
+    the raw contents of every source file, formatted as `=== <path> ===` blocks.
+
+    Produce a Markdown analysis titled `# Codebase Analysis` with the following
+    sections, in this order:
+
+    - **Stack** — language, framework, runtime version, key libraries (cite the file that shows each).
+    - **Entry points** — how the service / library starts, what it exposes.
+    - **Module layout** — a one-line summary of each top-level directory and file.
+    - **Public surface** — HTTP routes / CLI commands / library exports. For each, name, purpose, inputs, outputs.
+    - **Data model** — the core domain types and how they flow through the system.
+    - **Conventions** — naming, error handling, validation, dependency style.
+    - **Risks and sharp edges** — anything a new joiner would get wrong without being told.
+
+    Be specific. Reference actual function names and file paths.
+    Do not invent anything not present in the provided contents.
+    Do not ask for more information — always produce the analysis with what is given.
+
+    Markdown formatting rules — MANDATORY:
+    - Every table row on a SINGLE line. Never split a row across multiple lines.
+      Format: `| cell one | cell two |` (all on one line).
+    - Header separator on a single line too, e.g. `|---|---|`.
+    - Don't wrap cell contents; abbreviate long cells rather than breaking them.
+    - Keep paragraphs on one line; rely on blank lines for breaks.
+
+    Use the filesystem tools to also persist this analysis as an artifact.
+    The caller will specify an output directory in the user input; take the
+    path exactly as given and:
+    1. Use create-directory to ensure that directory exists.
+    2. Use write-file to save the full Markdown as `<output-dir>/analysis.md`.
+
+    Return the FULL analysis Markdown as your reply (downstream agents consume
+    it via prev-query). The filesystem write is a side-effect so a human can
+    open `<output-dir>/analysis.md` on its own. Calling the write-file tool
+    is MANDATORY — never skip it. If a tool call returns an error, retry it
+    once before giving up; never tell the user "permission issue, save it
+    manually" — complete the write.
+  tools:
+    - type: mcp
+      name: mcp-filesystem-create-directory
+    - type: mcp
+      name: mcp-filesystem-write-file
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: research-buddy-openai-responses
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+  annotations:
+    executor-openai-responses.ark.mckinsey.com/reasoning: {{ printf "{\"effort\": \"%s\"}" .Values.researchBuddy.reasoningEffort | quote }}
+    executor-openai-responses.ark.mckinsey.com/tools: |
+      [{"type": "web_search_preview",
+        "user_location": {"type": "approximate", "country": {{ .Values.researchBuddy.webSearchLocation.country | quote }}, "city": {{ .Values.researchBuddy.webSearchLocation.city | quote }}, "region": {{ .Values.researchBuddy.webSearchLocation.region | quote }}}}]
+spec:
+  description: Finds current public documentation and best practices for a stack
+  executionEngine:
+    name: {{ .Values.executionEngines.openaiResponses.name }}
+  modelRef:
+    name: {{ .Values.models.responses.name }}
+  prompt: |
+    You are a research assistant. Given a short description of a codebase's stack
+    (language, framework, libraries), use web search to gather the most useful
+    public references a new joiner would want pinned on day one.
+
+    Return, as a concise bulleted list:
+
+    - Official documentation URLs for the primary framework and runtime.
+    - The canonical getting-started / quickstart guide for each key library used.
+    - One or two high-signal best-practice or style guides for this stack.
+    - Any known common pitfalls specific to the versions in use.
+
+    For every item include: title, URL, one sentence on why it matters.
+    Prefer current, authoritative sources (official project sites, language
+    organisations, well-known maintainers). Skip marketing pages and SEO farms.
+
+    DO NOT ask the user or any upstream agent for more information. If specific
+    library or runtime versions are not provided, assume the latest stable
+    releases as of today and proceed. Always return the bulleted reference list
+    — never return a question, never return a request for clarification.
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: onboarding-writer-completions
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  description: Synthesises the analysis and research into ONBOARDING.md and writes it to disk
+  modelRef:
+    name: {{ .Values.models.default.name }}
+  prompt: |
+    You are a technical writer producing a new joiner onboarding guide for a codebase.
+
+    You will be given two inputs:
+    - A structural analysis of the codebase (stack, layout, entry points, public surface, data model, conventions, risks).
+    - A curated set of external references (official docs, quickstarts, style guides, known pitfalls).
+
+    Produce a single Markdown document titled "# Onboarding Guide" with the following sections, in this order:
+
+    1. **What this service does** — two sentences, plain English.
+    2. **Stack at a glance** — bullet list: language, framework, runtime, key libraries.
+    3. **Getting started locally** — numbered steps derived from the code and deps, not invented.
+    4. **Where things live** — one line per top-level directory/file, in a compact table.
+    5. **How a request flows through the system** — a short trace from entry point to handler.
+    6. **Public interface** — table of the service's routes / commands with purpose, inputs, outputs.
+    7. **Conventions** — bullets.
+    8. **Sharp edges** — bullets.
+    9. **External references** — the curated links, each with a one-line reason.
+
+    Markdown formatting rules — these are MANDATORY:
+    - Every table row must be on a SINGLE line. Never split a row across multiple
+      lines. Never put a newline between a pipe and the next cell.
+    - Format: `| cell one | cell two | cell three |` (all on one line).
+    - The header separator row must also be one line, e.g. `|---|---|---|`.
+    - Do not wrap cell contents. If a cell would be very long, abbreviate —
+      never break it with a newline.
+    - Keep each paragraph on one line (rely on surrounding blank lines for
+      paragraph breaks); do not insert hard line breaks inside a paragraph.
+    - Use triple-backtick fenced code blocks for code, never indented blocks.
+
+    After producing the Markdown content, use the filesystem tools.
+    The caller will specify an output directory in the user input; take the
+    path exactly as given and:
+    1. Use create-directory to ensure that directory exists.
+    2. Use write-file to save the Markdown as `<output-dir>/ONBOARDING.md`.
+
+    Do not print the Markdown content back to the conversation — only confirm the file was written and report its path.
+
+    DO NOT ask for more information, DO NOT return a question. You always have
+    enough context. If one of the upstream inputs is sparse or missing, proceed
+    using only what is provided and make reasonable assumptions (flag them as
+    "assumed" in the Markdown). The FINAL step of your work is ALWAYS calling
+    the write-file tool to save `<output-dir>/ONBOARDING.md` — do not skip it
+    under any circumstance.
+  tools:
+    - type: mcp
+      name: mcp-filesystem-create-directory
+    - type: mcp
+      name: mcp-filesystem-write-file
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: ticket-suggester-claude-sdk
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  description: Proposes a good-first-ticket for the analysed codebase
+  executionEngine:
+    name: {{ .Values.executionEngines.claudeAgentSdk.name }}
+  modelRef:
+    name: {{ .Values.models.anthropic.name }}
+  prompt: |
+    You are a tech lead helping a new joiner pick their first ticket on an unfamiliar
+    codebase. You will receive the structured analysis a senior engineer just produced
+    for the repo (stack, entry points, public surface, data model, conventions, and
+    sharp edges).
+
+    Propose ONE good first ticket. Pick something that is:
+    - Small in scope (can reasonably ship in a day or two)
+    - Low-risk (does not touch critical path or require deep domain knowledge)
+    - Visibly valuable (a sharp edge the analysis flagged, a missing validation, a
+      missing convenience, a small observability or ergonomics improvement)
+    - Instructive (the new joiner will learn the codebase by doing it)
+
+    Format your response exactly like this, in plain Markdown, no preamble:
+
+    **Title:** <one-line ticket title>
+
+    **Why this one:** <2 sentences on why it is a good first ticket specifically for
+    a new joiner, grounded in the analysis above.>
+
+    **Acceptance criteria:**
+    - <3-5 concrete, checkable bullet points>
+
+    **Files likely to touch:** <comma-separated list of file paths from the analysis>
+
+    **Estimated effort:** <S / M>  (S ≈ half a day, M ≈ one or two days)
+
+    **Stretch follow-up:** <one optional next ticket this unlocks>
+
+    Return only the ticket. No other text, no closing remarks.

--- a/demos/onboarding-guide-bundle/chart/templates/anthropic-model.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/anthropic-model.yaml
@@ -1,0 +1,19 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: {{ .Values.models.anthropic.name }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  provider: anthropic
+  model:
+    value: {{ .Values.models.anthropic.modelId | quote }}
+  config:
+    anthropic:
+      baseUrl:
+        value: {{ .Values.models.anthropic.baseUrl | quote }}
+      apiKey:
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "onboarding.anthropicSecretName" . }}
+            key: apiKey

--- a/demos/onboarding-guide-bundle/chart/templates/anthropic-secret.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/anthropic-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.anthropic.apiKey (not .Values.anthropic.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.anthropic.secretName }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  apiKey: {{ .Values.anthropic.apiKey | quote }}
+{{- end }}

--- a/demos/onboarding-guide-bundle/chart/templates/mcp-filesystem.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/mcp-filesystem.yaml
@@ -1,0 +1,15 @@
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: mcp-filesystem
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  description: "MCP Filesystem Server used by default-executor agents to read/write workflow artifacts"
+  transport: http
+  address:
+    valueFrom:
+      serviceRef:
+        name: file-gateway-filesystem-mcp
+        port: web
+        path: /mcp

--- a/demos/onboarding-guide-bundle/chart/templates/rbac.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/rbac.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.argoWorkflows.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-argo-workflow-ark-access
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["ark.mckinsey.com"]
+    resources: ["queries"]
+    verbs: ["create", "get", "list", "watch", "patch", "update", "delete"]
+  - apiGroups: ["ark.mckinsey.com"]
+    resources: ["agents", "models", "tools", "mcpservers", "a2aservers", "teams", "memories"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets", "services"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-argo-workflow-ark-access
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-argo-workflow-ark-access
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.argoWorkflows.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-argo-workflow-edit-access
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-edit
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.argoWorkflows.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/demos/onboarding-guide-bundle/chart/templates/service-account.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/service-account.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.argoWorkflows.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.argoWorkflows.serviceAccountName }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+{{- end }}

--- a/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
@@ -1,0 +1,286 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: onboarding-generate
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+  annotations:
+    workflows.argoproj.io/title: "Generate onboarding guide"
+    workflows.argoproj.io/description: "Reads a repo, analyses it with Claude, researches best practices with OpenAI Responses + web search, then writes ONBOARDING.md"
+spec:
+  entrypoint: generate-onboarding
+  serviceAccountName: {{ .Values.argoWorkflows.serviceAccountName }}
+  arguments:
+    parameters:
+      - name: repo-url
+        value: ""
+
+  templates:
+    - name: generate-onboarding
+      dag:
+        tasks:
+          - name: read-repo
+            template: ark-query
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "read-repo"
+                - name: prompt
+                  value: "Clone the repository at {{`{{workflow.parameters.repo-url}}`}} and return the file tree plus the full contents of every source file, as described in your instructions."
+                - name: prev-query
+                  value: ""
+                - name: prev-query-2
+                  value: ""
+                - name: target-type
+                  value: agent
+                - name: target-name
+                  value: repo-reader-claude-sdk
+                - name: timeout
+                  value: "5m"
+
+          - name: analyze-code
+            template: ark-query
+            depends: "read-repo"
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "analyze-code"
+                - name: prompt
+                  value: "Produce the structured analysis described in your instructions, based on the repository contents below. Output directory for this run: output/{{`{{workflow.name}}`}}"
+                - name: prev-query
+                  value: "{{`{{tasks.read-repo.outputs.parameters.query-name}}`}}"
+                - name: prev-query-2
+                  value: ""
+                - name: target-type
+                  value: agent
+                - name: target-name
+                  value: code-analyzer-completions
+                - name: timeout
+                  value: "5m"
+
+          - name: research-stack
+            template: ark-query
+            depends: "read-repo"
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "research-stack"
+                - name: prompt
+                  value: "Using the stack hint produced by the upstream surveyor, search the web for the most useful public references a new joiner to this stack would want pinned on day one: official docs, quickstarts, style guides, and known pitfalls for the exact versions in use."
+                - name: prev-query
+                  value: "{{`{{tasks.read-repo.outputs.parameters.query-name}}`}}"
+                - name: prev-query-2
+                  value: ""
+                - name: target-type
+                  value: agent
+                - name: target-name
+                  value: research-buddy-openai-responses
+                - name: timeout
+                  value: "5m"
+
+          - name: write-onboarding
+            template: ark-query
+            depends: "analyze-code && research-stack"
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "write-onboarding"
+                - name: prompt
+                  value: "Synthesise the structural analysis and the external references below into a new joiner ONBOARDING.md. Output directory for this run: output/{{`{{workflow.name}}`}} — write the result to output/{{`{{workflow.name}}`}}/ONBOARDING.md via the filesystem tools. Do not print the content back to this conversation — only confirm the file was written."
+                - name: prev-query
+                  value: "{{`{{tasks.analyze-code.outputs.parameters.query-name}}`}}"
+                - name: prev-query-2
+                  value: "{{`{{tasks.research-stack.outputs.parameters.query-name}}`}}"
+                - name: target-type
+                  value: agent
+                - name: target-name
+                  value: onboarding-writer-completions
+                - name: timeout
+                  value: "5m"
+
+          - name: suggest-ticket
+            template: ark-query
+            depends: "write-onboarding"
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "suggest-ticket"
+                - name: prompt
+                  value: "Using the codebase analysis below, propose ONE good-first-ticket for a new joiner following the format in your instructions."
+                - name: prev-query
+                  value: "{{`{{tasks.analyze-code.outputs.parameters.query-name}}`}}"
+                - name: prev-query-2
+                  value: ""
+                - name: target-type
+                  value: agent
+                - name: target-name
+                  value: ticket-suggester-claude-sdk
+                - name: timeout
+                  value: "3m"
+
+          - name: write-ticket
+            template: write-ticket
+            depends: "suggest-ticket"
+            arguments:
+              parameters:
+                - name: query-name
+                  value: "{{`{{tasks.suggest-ticket.outputs.parameters.query-name}}`}}"
+                - name: output-dir
+                  value: "output/{{`{{workflow.name}}`}}"
+
+          - name: summary
+            template: summary
+            depends: "write-ticket"
+
+    - name: ark-query
+      inputs:
+        parameters:
+          - name: query-name
+          - name: prompt
+          - name: prev-query
+          - name: prev-query-2
+          - name: target-type
+          - name: target-name
+          - name: timeout
+      script:
+        image: alpine/k8s:1.28.13
+        command: [sh]
+        source: |
+          set -eu
+          apk add --no-cache jq > /dev/null 2>&1
+
+          QUERY_NAME="{{`{{inputs.parameters.query-name}}`}}-{{`{{workflow.name}}`}}-$(date +%s%N | tail -c 10)"
+          SAFE_NAME=$(echo "$QUERY_NAME" | tr '.' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-63)
+          echo "$SAFE_NAME" > /tmp/query-name.txt
+
+          cat > /tmp/prompt.txt << 'PROMPTEOF'
+          {{`{{inputs.parameters.prompt}}`}}
+          PROMPTEOF
+
+          PREV_QUERY="{{`{{inputs.parameters.prev-query}}`}}"
+          PREV_QUERY_2="{{`{{inputs.parameters.prev-query-2}}`}}"
+
+          if [ -n "$PREV_QUERY" ]; then
+            echo "" >> /tmp/prompt.txt
+            echo "--- Previous output ---" >> /tmp/prompt.txt
+            kubectl get query "$PREV_QUERY" -o jsonpath='{.status.response.content}' >> /tmp/prompt.txt
+          fi
+
+          if [ -n "$PREV_QUERY_2" ]; then
+            echo "" >> /tmp/prompt.txt
+            echo "--- Additional context ---" >> /tmp/prompt.txt
+            kubectl get query "$PREV_QUERY_2" -o jsonpath='{.status.response.content}' >> /tmp/prompt.txt
+          fi
+
+          MCP_ANNOTATION='{"default/mcp-filesystem": {"toolCalls": [{"name": "set_base_directory", "arguments": {"path": "."}}]}}'
+
+          echo "========================================"
+          echo "AGENT     : {{`{{inputs.parameters.target-type}}`}}/{{`{{inputs.parameters.target-name}}`}}"
+          echo "QUERY NAME: $SAFE_NAME"
+          echo "========================================"
+          echo "---- INPUT ----"
+          cat /tmp/prompt.txt
+          echo ""
+          echo "---- END INPUT ----"
+
+          jq -n \
+            --rawfile input /tmp/prompt.txt \
+            --arg name "$SAFE_NAME" \
+            --arg wf "{{`{{workflow.name}}`}}" \
+            --arg mcp "$MCP_ANNOTATION" \
+            --arg target_name "{{`{{inputs.parameters.target-name}}`}}" \
+            --arg target_type "{{`{{inputs.parameters.target-type}}`}}" \
+            --arg timeout "{{`{{inputs.parameters.timeout}}`}}" \
+            '{
+              apiVersion: "ark.mckinsey.com/v1alpha1",
+              kind: "Query",
+              metadata: {
+                name: $name,
+                labels: {workflow: $wf},
+                annotations: {"ark.mckinsey.com/mcp-server-settings": $mcp}
+              },
+              spec: {
+                input: $input,
+                target: {name: $target_name, type: $target_type},
+                timeout: $timeout,
+                ttl: "1h"
+              }
+            }' | kubectl apply -f -
+
+          # Wait until the query leaves the 'running' phase. If it errored, fail this step so Argo surfaces it.
+          until [ "$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)" != "running" ] \
+                && [ -n "$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)" ]; do
+            sleep 3
+          done
+          PHASE=$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}')
+          DURATION=$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.duration}')
+          echo ""
+          echo "query $SAFE_NAME finished phase=$PHASE duration=$DURATION"
+
+          echo "---- OUTPUT ----"
+          kubectl get query "$SAFE_NAME" -o jsonpath='{.status.response.content}'
+          echo ""
+          echo "---- END OUTPUT ----"
+
+          if [ "$PHASE" != "done" ]; then
+            echo "query error: $(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.conditions[0].message}')"
+            exit 1
+          fi
+      outputs:
+        parameters:
+          - name: query-name
+            valueFrom:
+              path: /tmp/query-name.txt
+
+    - name: write-ticket
+      inputs:
+        parameters:
+          - name: query-name
+          - name: output-dir
+      script:
+        image: alpine/k8s:1.28.13
+        command: [sh]
+        source: |
+          set -eu
+          QUERY_NAME="{{`{{inputs.parameters.query-name}}`}}"
+          OUTPUT_DIR="{{`{{inputs.parameters.output-dir}}`}}"
+
+          echo "fetching ticket content from query $QUERY_NAME"
+          kubectl get query "$QUERY_NAME" -o jsonpath='{.status.response.content}' > /tmp/TICKET.md
+          SIZE=$(wc -c < /tmp/TICKET.md | tr -d ' ')
+          echo "ticket size: ${SIZE} bytes"
+
+          if [ "$SIZE" -lt 20 ]; then
+            echo "FAILED: ticket content is suspiciously small (${SIZE} bytes)"
+            exit 1
+          fi
+
+          echo "uploading to file-gateway under ${OUTPUT_DIR}/"
+          CODE=$(curl -sS -o /tmp/resp -w "%{http_code}" \
+            -X POST "http://file-gateway-api/files" \
+            -F "file=@/tmp/TICKET.md" \
+            -F "prefix=${OUTPUT_DIR}/")
+          if [ "$CODE" != "200" ] && [ "$CODE" != "201" ]; then
+            echo "FAILED HTTP $CODE: $(cat /tmp/resp)"
+            exit 1
+          fi
+          echo "wrote ${OUTPUT_DIR}/TICKET.md"
+
+    - name: summary
+      container:
+        image: alpine:3.19
+        command: [sh, -c]
+        args:
+          - |
+            echo "==========================================="
+            echo "    ONBOARDING GUIDE GENERATED             "
+            echo "==========================================="
+            echo "Source: {{`{{workflow.parameters.repo-url}}`}}"
+            echo "Output dir: output/{{`{{workflow.name}}`}}/"
+            echo "  - analysis.md   (from code-analyzer-completions)"
+            echo "  - ONBOARDING.md (from onboarding-writer-completions)"
+            echo "  - TICKET.md     (from ticket-suggester-claude-sdk)"
+            echo ""
+            echo "Fetch all three files to your laptop with:"
+            echo "  kubectl cp ... # see README for fetch instructions {{`{{workflow.name}}`}}"
+            echo "==========================================="

--- a/demos/onboarding-guide-bundle/chart/values.yaml
+++ b/demos/onboarding-guide-bundle/chart/values.yaml
@@ -1,0 +1,69 @@
+# Onboarding Guide Bundle configuration.
+# Override with --set or -f custom-values.yaml at install time.
+
+# Labels applied to every resource created by this chart.
+commonLabels:
+  app.kubernetes.io/part-of: onboarding-guide-bundle
+
+# Anthropic credentials.
+# Either provide a plain apiKey here (chart will create a Secret), or set
+# existingSecretName to an existing Secret with an `apiKey` field.
+anthropic:
+  apiKey: ""
+  existingSecretName: ""
+  # Name of the Secret the chart creates when apiKey is provided.
+  secretName: anthropic-api-key
+
+# Models referenced by the agents. You must create these Model CRs in the
+# target namespace before running the workflow — this bundle does not create
+# them. `default` and `responses` are assumed to exist already (typical Ark
+# cluster setup); the chart creates the Anthropic Model from the credentials
+# above.
+models:
+  # Default completions-compatible model (any provider). Used by
+  # code-analyzer-completions and onboarding-writer-completions.
+  default:
+    name: default
+  # OpenAI Responses-compatible model (provider: openai). Used by
+  # research-buddy-openai-responses.
+  responses:
+    name: responses
+  # Anthropic model created by this chart from anthropic.apiKey (or a
+  # pre-existing Secret). Used by repo-reader-claude-sdk and
+  # ticket-suggester-claude-sdk.
+  anthropic:
+    name: anthropic
+    modelId: claude-sonnet-4-5
+    baseUrl: https://api.anthropic.com
+
+# Execution engines must be installed separately via `ark install`:
+#   ark install marketplace/executors/executor-openai-responses --marketplace-version 0.1.3 -y
+#   ark install marketplace/executors/executor-claude-agent-sdk -y
+# (Pin executor-openai-responses to 0.1.3 — 0.1.4 ships a broken build.)
+executionEngines:
+  claudeAgentSdk:
+    name: executor-claude-agent-sdk
+  openaiResponses:
+    name: executor-openai-responses
+
+# file-gateway provides the filesystem MCP the default-executor agents use to
+# write outputs, and the HTTP API for uploads/downloads. Set to false and
+# install file-gateway separately (or re-use the namespace's existing one).
+file-gateway:
+  enabled: true
+
+# Research-buddy annotation configuration. Override to localise web search or
+# to tune reasoning effort.
+researchBuddy:
+  reasoningEffort: low
+  webSearchLocation:
+    country: GB
+    city: London
+    region: London
+
+# Argo Workflows ServiceAccount + RBAC. The workflow's ark-query step creates
+# Query CRs via kubectl, so the SA needs ark.mckinsey.com/queries permissions.
+argoWorkflows:
+  rbac:
+    enabled: true
+  serviceAccountName: argo-workflow

--- a/demos/onboarding-guide-bundle/scripts/fetch-output.sh
+++ b/demos/onboarding-guide-bundle/scripts/fetch-output.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+WF_NAME="${1:-}"
+NAMESPACE="${2:-default}"
+
+if [ -z "$WF_NAME" ]; then
+    WF_NAME=$(kubectl -n "$NAMESPACE" get wf -o json 2>/dev/null \
+      | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = [w for w in data.get('items', [])
+         if w.get('spec', {}).get('workflowTemplateRef', {}).get('name') == 'onboarding-generate']
+items.sort(key=lambda w: w['metadata'].get('creationTimestamp',''), reverse=True)
+print(items[0]['metadata']['name'] if items else '')
+")
+    if [ -z "$WF_NAME" ]; then
+        echo "ERROR: no Workflow found with workflowTemplateRef=onboarding-generate."
+        echo "       Pass the workflow name explicitly: $0 <workflow-name>"
+        exit 1
+    fi
+    echo "Using latest workflow: $WF_NAME"
+fi
+
+REMOTE_DIR="output/${WF_NAME}"
+LOCAL_DIR="./output/${WF_NAME}"
+REMOTE_FILES=("analysis.md" "ONBOARDING.md" "TICKET.md")
+
+mkdir -p "$LOCAL_DIR"
+
+echo "=== port-forwarding file-gateway-api ==="
+kubectl -n "$NAMESPACE" port-forward svc/file-gateway-api 18080:80 >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill $PF_PID 2>/dev/null || true' EXIT
+sleep 2
+
+ANY_OK=0
+for NAME in "${REMOTE_FILES[@]}"; do
+    LOCAL_PATH="$LOCAL_DIR/$NAME"
+    REMOTE_KEY="$REMOTE_DIR/$NAME"
+    HTTP=$(curl -sS -o "$LOCAL_PATH" -w "%{http_code}" \
+        "http://localhost:18080/files/$REMOTE_KEY/download" || echo "000")
+    if [ "$HTTP" = "200" ]; then
+        SIZE=$(wc -c < "$LOCAL_PATH" | tr -d ' ')
+        echo "  ✓ $REMOTE_KEY -> $LOCAL_PATH  ($SIZE bytes)"
+        ANY_OK=1
+    else
+        echo "  ✗ $REMOTE_KEY (HTTP $HTTP)"
+        rm -f "$LOCAL_PATH"
+    fi
+done
+
+if [ "$ANY_OK" = "0" ]; then
+    echo ""
+    echo "ERROR: no files downloaded from $REMOTE_DIR."
+    echo "       Check that the workflow '$WF_NAME' finished:"
+    echo "         kubectl -n $NAMESPACE get wf $WF_NAME"
+    exit 1
+fi
+
+echo ""
+echo "Open the generated files:"
+for NAME in "${REMOTE_FILES[@]}"; do
+    LOCAL_PATH="$LOCAL_DIR/$NAME"
+    [ -f "$LOCAL_PATH" ] && echo "  open \"$LOCAL_PATH\""
+done

--- a/executors/claude-agent-sdk/chart/templates/rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools", "mcpservers"]
+    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]


### PR DESCRIPTION
## Summary
- Adds a new demo bundle under `demos/onboarding-guide-bundle/` that turns any public git URL into three first-class artifacts a new joiner needs: a structural `analysis.md`, a new-joiner `ONBOARDING.md`, and a `TICKET.md` proposing a good first issue.
- Five-agent Argo workflow that exercises three execution engines in one DAG — Claude Agent SDK (clone + ticket), OpenAI Responses (+ `web_search_preview` for live web research), and the default completions executor (with the file-gateway filesystem MCP for analysis + writing).
- Ships as a standard Helm chart mirroring the shape of `cobol-modernization-bundle` / `kyc-*-bundle`: `file-gateway` as an OCI dependency, Argo Workflow RBAC, Anthropic Secret + Model created from `anthropic.apiKey` or an existing secret, and a `Makefile` with `build` / `install-with-argo` / `onboarding-demo` / `fetch-output` / `uninstall` targets.

## DAG

\`\`\`
repo-reader-claude-sdk   →   code-analyzer-completions ┐
                          ↘                             ├→ onboarding-writer-completions → ticket-suggester-claude-sdk → write-ticket (Argo script) → summary
                             research-buddy-openai-responses ┘
\`\`\`

Each run writes to its own \`output/<workflow-name>/\` folder on file-gateway so runs don't overwrite each other. \`scripts/fetch-output.sh\` pulls all three artifacts with one command.

## Prerequisites
- \`default\` and \`responses\` Models present in the target namespace.
- Claude Agent SDK and OpenAI Responses executors installed separately via \`ark install marketplace/executors/...\`. Pin \`executor-openai-responses\` to \`0.1.3\` — \`0.1.4\` ships a broken build (\`stream_chunk\` AttributeError).
- \`ANTHROPIC_API_KEY\` set at install time, or a pre-existing \`Secret\` named via \`anthropic.existingSecretName\`.

## Validation
- \`helm dependency build\` + \`helm lint\` + \`helm template\` all clean with the new chart (file-gateway is pulled from the OCI registry as expected).
- Argo \`{{workflow.parameters.repo-url}}\`, \`{{tasks.*.outputs.*}}\`, and \`{{inputs.parameters.*}}\` are rendered verbatim through Helm (escaped so Helm does not consume them).
- End-to-end verified on minikube against \`https://github.com/karpathy/micrograd\` — full 7-node DAG completes in ~2-3 minutes and produces \`analysis.md\`, \`ONBOARDING.md\`, and \`TICKET.md\` grounded in the cloned source.

## Notes for reviewers
- \`ticket-suggester-claude-sdk\` runs on the Claude Agent SDK executor, which cannot currently reach cluster-side \`MCPServer\` CRDs from inside its sandbox. A tiny non-agent Argo step (\`write-ticket\`) reads the query response via \`kubectl\` and POSTs it to file-gateway, so the ticket still lands as a file alongside the other two artifacts.
- Similarly \`repo-reader-claude-sdk\` uses Claude Code's bundled shell / Read tools to clone (the default executor has no shell or network egress), then returns the raw dump as text; downstream agents consume it via Argo \`prev-query\` wiring.