### PR TITLE
feat(executors): add broker streaming support to LangChain and Claude…

### DIFF
--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple
 from ark_sdk.executor import BaseExecutor, MCPServerConfig, Message
 from ark_sdk.executor_app import is_otel_enabled
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, list_sessions
+from claude_agent_sdk.types import AssistantMessage, TextBlock
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,10 @@ class ClaudeAgentExecutor(BaseExecutor):
             async with ClaudeSDKClient(options=options) as client:
                 await client.query(user_input)
                 async for message in client.receive_response():
+                    if isinstance(message, AssistantMessage):
+                        for block in message.content:
+                            if isinstance(block, TextBlock) and block.text:
+                                await self.stream_chunk(block.text)
                     if hasattr(message, "result") and message.result:
                         result_text = message.result
 

--- a/executors/claude-agent-sdk/tests/conftest.py
+++ b/executors/claude-agent-sdk/tests/conftest.py
@@ -1,0 +1,102 @@
+"""Stub out claude_agent_sdk for local test runs (the real package is Docker/Linux-only)."""
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+def _build_stub() -> None:
+    if "claude_agent_sdk" in sys.modules:
+        return
+
+    @dataclass
+    class TextBlock:
+        text: str
+
+    @dataclass
+    class ThinkingBlock:
+        thinking: str
+        signature: str
+
+    @dataclass
+    class ToolUseBlock:
+        id: str
+        name: str
+        input: dict = field(default_factory=dict)
+
+    @dataclass
+    class ToolResultBlock:
+        tool_use_id: str
+        content: str
+
+    @dataclass
+    class AssistantMessage:
+        content: list
+        model: str
+        parent_tool_use_id: Optional[str] = None
+        error: Optional[str] = None
+
+    @dataclass
+    class ResultMessage:
+        subtype: str = "success"
+        duration_ms: int = 0
+        duration_api_ms: int = 0
+        is_error: bool = False
+        num_turns: int = 0
+        session_id: str = ""
+        total_cost_usd: Optional[float] = None
+        usage: Optional[dict] = None
+        result: Optional[str] = None
+        structured_output: Any = None
+
+    @dataclass
+    class ClaudeAgentOptions:
+        model: str = ""
+        cwd: str = "."
+        permission_mode: str = "default"
+        env: dict = field(default_factory=dict)
+        mcp_servers: Optional[dict] = None
+        allowed_tools: Optional[list] = None
+        resume: Optional[str] = None
+
+    class ClaudeSDKClient:
+        def __init__(self, options=None):
+            self.options = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def query(self, prompt):
+            pass
+
+        async def receive_response(self):
+            return
+            yield
+
+    def list_sessions(directory=".", limit=10):
+        return []
+
+    sdk_types = types.ModuleType("claude_agent_sdk.types")
+    sdk_types.TextBlock = TextBlock
+    sdk_types.ThinkingBlock = ThinkingBlock
+    sdk_types.ToolUseBlock = ToolUseBlock
+    sdk_types.ToolResultBlock = ToolResultBlock
+    sdk_types.AssistantMessage = AssistantMessage
+    sdk_types.ResultMessage = ResultMessage
+    sdk_types.ClaudeAgentOptions = ClaudeAgentOptions
+
+    sdk = types.ModuleType("claude_agent_sdk")
+    sdk.ClaudeAgentOptions = ClaudeAgentOptions
+    sdk.ClaudeSDKClient = ClaudeSDKClient
+    sdk.list_sessions = list_sessions
+    sdk.types = sdk_types
+
+    sys.modules["claude_agent_sdk"] = sdk
+    sys.modules["claude_agent_sdk.types"] = sdk_types
+
+
+_build_stub()

--- a/executors/claude-agent-sdk/tests/test_streaming.py
+++ b/executors/claude-agent-sdk/tests/test_streaming.py
@@ -1,0 +1,179 @@
+"""Tests for broker streaming via stream_chunk in ClaudeAgentExecutor."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from claude_agent_sdk.types import AssistantMessage, TextBlock, ThinkingBlock
+from ark_sdk.executor import Message
+from claude_agent_executor.executor import ClaudeAgentExecutor
+
+
+def _model_config(name="claude-sonnet-4-20250514", api_key="sk-test"):
+    model = MagicMock()
+    model.name = name
+    model.config = {"anthropic": {"apiKey": api_key}}
+    return model
+
+
+def _request(conversation_id="conv-1", user_input="hello"):
+    request = MagicMock()
+    request.conversationId = conversation_id
+    request.userInput.content = user_input
+    request.agent.name = "test-agent"
+    request.agent.model = _model_config()
+    request.mcpServers = []
+    return request
+
+
+def _make_assistant_message(*texts):
+    return AssistantMessage(
+        content=[TextBlock(text=t) for t in texts],
+        model="claude-sonnet-4-20250514",
+    )
+
+
+def _make_result_message(result="final answer"):
+    msg = MagicMock()
+    msg.result = result
+    return msg
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_stream_chunk_called_for_assistant_text_blocks(self, tmp_path):
+        executor = ClaudeAgentExecutor()
+        chunks = []
+
+        async def capture_chunk(text):
+            chunks.append(text)
+
+        executor.stream_chunk = capture_chunk
+
+        class FakeClient:
+            def __init__(self, options=None):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                yield _make_assistant_message("Hello ", "world")
+                yield _make_result_message("Hello world")
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            result = await executor.execute_agent(_request())
+
+        assert chunks == ["Hello ", "world"]
+        assert result == [Message(role="assistant", content="Hello world", name="test-agent")]
+
+    @pytest.mark.asyncio
+    async def test_non_text_blocks_not_streamed(self, tmp_path):
+        executor = ClaudeAgentExecutor()
+        chunks = []
+
+        async def capture_chunk(text):
+            chunks.append(text)
+
+        executor.stream_chunk = capture_chunk
+
+        class FakeClient:
+            def __init__(self, options=None):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                msg = AssistantMessage(
+                    content=[
+                        ThinkingBlock(thinking="internal thought", signature="sig"),
+                        TextBlock(text="visible text"),
+                    ],
+                    model="claude-sonnet-4-20250514",
+                )
+                yield msg
+                yield _make_result_message("visible text")
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(_request())
+
+        assert chunks == ["visible text"]
+
+    @pytest.mark.asyncio
+    async def test_no_assistant_messages_no_stream_chunks(self, tmp_path):
+        executor = ClaudeAgentExecutor()
+        chunks = []
+
+        async def capture_chunk(text):
+            chunks.append(text)
+
+        executor.stream_chunk = capture_chunk
+
+        class FakeClient:
+            def __init__(self, options=None):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                yield _make_result_message("done")
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(_request())
+
+        assert chunks == []
+
+    @pytest.mark.asyncio
+    async def test_empty_text_blocks_not_streamed(self, tmp_path):
+        executor = ClaudeAgentExecutor()
+        chunks = []
+
+        async def capture_chunk(text):
+            chunks.append(text)
+
+        executor.stream_chunk = capture_chunk
+
+        class FakeClient:
+            def __init__(self, options=None):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                yield _make_assistant_message("")
+                yield _make_result_message("done")
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(_request())
+
+        assert chunks == []

--- a/executors/claude-agent-sdk/uv.lock
+++ b/executors/claude-agent-sdk/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "ark-sdk"
-version = "0.1.57"
+version = "0.1.60"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -205,7 +205,7 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/14/3f84b1a969b7e176e32ed97afb26483bc46123d99e1ffb207e6ed4ffddd1/ark_sdk-0.1.57-py3-none-any.whl", hash = "sha256:5632b9865cb4175eb80542616efd3cf4ddb16f8cb6a19ebb1957f55b9d144f68", size = 203034, upload-time = "2026-04-02T15:22:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/94/2593dc1aa331e6a390c137090b200e4fcb36b58260fe657e17072a7823ee/ark_sdk-0.1.60-py3-none-any.whl", hash = "sha256:e2889beb35893b8ee246b45ab9738ccd74e8d5efb718fd4fce7b98a50895d302", size = 206662, upload-time = "2026-04-21T09:35:18.927Z" },
 ]
 
 [[package]]
@@ -530,7 +530,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.0" },
-    { name = "ark-sdk", specifier = ">=0.1.56" },
+    { name = "ark-sdk", specifier = "==0.1.60" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "kubernetes-asyncio", specifier = ">=31.0.0" },

--- a/executors/langchain/chart/templates/rbac.yaml
+++ b/executors/langchain/chart/templates/rbac.yaml
@@ -13,10 +13,10 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools"]
+    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/executors/langchain/src/langchain_executor/executor.py
+++ b/executors/langchain/src/langchain_executor/executor.py
@@ -67,13 +67,12 @@ class LangChainExecutor(BaseExecutor):
 
             history.add_message(HumanMessage(content=user_content))
 
-            response = await chat_client.ainvoke(history.messages)
-
-            # Handle response content
-            if hasattr(response, "content"):
-                result = str(response.content)
-            else:
-                result = str(response)
+            result = ""
+            async for chunk in chat_client.astream(history.messages):
+                token = chunk.content if hasattr(chunk, "content") else str(chunk)
+                if token:
+                    await self.stream_chunk(token)
+                    result += token
 
             history.add_message(AIMessage(content=result))
 


### PR DESCRIPTION
… Agent SDK executors

## Summary
- LangChain: switch from ainvoke to astream, calling stream_chunk() per token
- Claude Agent SDK: stream AssistantMessage TextBlock content via stream_chunk()
- Add conftest.py to stub claude_agent_sdk for local test runs (Docker/Linux-only wheel)
- Add test_streaming.py with 4 tests covering streaming behaviour