### PR TITLE
fix(kyc-onboarding-bundle): correct filesystem MCP tool name prefix in agent and workflow templates

### DIFF
--- a/demos/kyc-onboarding-bundle/Makefile
+++ b/demos/kyc-onboarding-bundle/Makefile
@@ -377,9 +377,9 @@ verify-mcp:
 	@kubectl get pods -n $(NAMESPACE) -l app=web-research-mcp 2>/dev/null || true
 
 wait-for-tools:
-	@echo "Waiting for Tool mcp-filesystem-read-file..."
+	@echo "Waiting for Tool filesystem-mcp-server-read-file..."
 	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do \
-		if kubectl get tools -n $(NAMESPACE) --request-timeout=5s 2>/dev/null | grep -q mcp-filesystem-read-file; then \
+		if kubectl get tools -n $(NAMESPACE) --request-timeout=5s 2>/dev/null | grep -q filesystem-mcp-server-read-file; then \
 			echo "Found."; \
 			exit 0; \
 		fi; \

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/beneficial-owner-tree-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/beneficial-owner-tree-agent.yaml
@@ -214,9 +214,9 @@ spec:
   
   tools:
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
       name: perplexity-ask
     - type: built-in

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/ch-analyst-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/ch-analyst-agent.yaml
@@ -374,11 +374,11 @@ spec:
 
   tools:
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
     - type: built-in
       name: terminate
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/ch-api-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/ch-api-agent.yaml
@@ -272,11 +272,11 @@ spec:
     - type: built-in
       name: terminate
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
     # Phase 2: Add Companies House MCP tools here
     # - type: mcp
     #   name: companies-house-search-company

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/consolidation-analyst-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/consolidation-analyst-agent.yaml
@@ -243,15 +243,15 @@ spec:
   tools:
     # MCP filesystem tools for reading and writing consolidated data
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
     - type: mcp
-      name: mcp-filesystem-search-files
+      name: filesystem-mcp-server-search-files
     - type: mcp
-      name: mcp-filesystem-get-file-info
+      name: filesystem-mcp-server-get-file-info
     - type: built-in
       name: terminate
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/file-manager-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/file-manager-agent.yaml
@@ -23,15 +23,15 @@ spec:
   description: |
     File I/O agent used across all teams. Read files with filesystem-read-file;
     save final document with filesystem-write-file. When saving, use entire content between three
-    backticks, excluding the backticks themselves. Uses mcp-filesystem tools.
+    backticks, excluding the backticks themselves. Uses filesystem-mcp-server tools.
 
   prompt: |
     You are a File Manager agent responsible for all file operations in KYC workflows.
-    Your role is to read from and write to files using the mcp-filesystem tools.
+    Your role is to read from and write to files using the filesystem-mcp-server tools.
     
     ## YOUR CAPABILITIES
     
-    You have access to the following mcp-filesystem tools:
+    You have access to the following filesystem-mcp-server tools:
     
     1. **filesystem-read-file** - Read file contents
        - Input: file path (relative to MCP base, e.g. source_code_files/...)
@@ -129,23 +129,23 @@ spec:
     name: {{ .Values.modelRef.name }}
 
   tools:
-    # mcp-filesystem tools
+    # filesystem-mcp-server tools
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
     - type: mcp
-      name: mcp-filesystem-create-directory
+      name: filesystem-mcp-server-create-directory
     - type: mcp
-      name: mcp-filesystem-get-file-info
+      name: filesystem-mcp-server-get-file-info
     - type: mcp
-      name: mcp-filesystem-move-file
+      name: filesystem-mcp-server-move-file
     - type: mcp
-      name: mcp-filesystem-search-files
+      name: filesystem-mcp-server-search-files
     - type: mcp
-      name: mcp-filesystem-directory-tree
+      name: filesystem-mcp-server-directory-tree
     
     - type: built-in
       name: terminate

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/rag-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/rag-agent.yaml
@@ -177,13 +177,13 @@ spec:
     
     # Filesystem tools for reading documents and writing results
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-get-file-info
+      name: filesystem-mcp-server-get-file-info
     - type: mcp
-      name: mcp-filesystem-create-directory
+      name: filesystem-mcp-server-create-directory
     
     - type: built-in
       name: terminate

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/relevance-classification-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/relevance-classification-agent.yaml
@@ -242,8 +242,8 @@ spec:
   
   tools:
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: built-in
       name: terminate

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/scout-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/scout-agent.yaml
@@ -135,9 +135,9 @@ spec:
   tools:
     # Filesystem tools
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-get-file-info
+      name: filesystem-mcp-server-get-file-info
     
     - type: built-in
       name: terminate

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/summary-assessment-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/summary-assessment-agent.yaml
@@ -284,8 +284,8 @@ spec:
   
   tools:
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: built-in
       name: terminate

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/web-analyst-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/web-analyst-agent.yaml
@@ -231,11 +231,11 @@ spec:
 
   tools:
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
     - type: mcp
       name: web-research-mcp-get-web-research-results
     - type: mcp

--- a/demos/kyc-onboarding-bundle/chart/templates/agents/web-researcher-agent.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/agents/web-researcher-agent.yaml
@@ -192,9 +192,9 @@ spec:
     - type: mcp
       name: web-research-mcp-list-web-evidence
     - type: mcp
-      name: mcp-filesystem-read-file
+      name: filesystem-mcp-server-read-file
     - type: mcp
-      name: mcp-filesystem-write-file
+      name: filesystem-mcp-server-write-file
     - type: mcp
-      name: mcp-filesystem-list-directory
+      name: filesystem-mcp-server-list-directory
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/teams/companies-house-team.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/teams/companies-house-team.yaml
@@ -36,7 +36,7 @@ spec:
     4. Critic validates data completeness
     5. File Manager saves Companies House data
     
-    When the user message specifies an exact output path (e.g. .../intermediate/government_data_initial_profile.json), the Companies House Analyst or File Manager MUST call mcp-filesystem-write-file to that path before the task is complete. The task is not done until that file exists. If the API Agent has no live data (e.g. Phase 1), the Analyst should still produce structured JSON from the plan and company number and save it to the specified path.
+    When the user message specifies an exact output path (e.g. .../intermediate/government_data_initial_profile.json), the Companies House Analyst or File Manager MUST call filesystem-mcp-server-write-file to that path before the task is complete. The task is not done until that file exists. If the API Agent has no live data (e.g. Phase 1), the Analyst should still produce structured JSON from the plan and company number and save it to the specified path.
     
     Limitation: Not capable of reading and extracting information from non-text formats.
   

--- a/demos/kyc-onboarding-bundle/chart/templates/teams/consolidation-team.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/teams/consolidation-team.yaml
@@ -31,8 +31,8 @@ spec:
     
     Workflow:
     1. Planner creates consolidation mission plan with merge logic
-    2. File Manager reads all source files (mcp-filesystem-read-file)
-    3. Analyst consolidates data per merge rules AND writes the output (mcp-filesystem-write-file)
+    2. File Manager reads all source files (filesystem-mcp-server-read-file)
+    3. Analyst consolidates data per merge rules AND writes the output (filesystem-mcp-server-write-file)
     4. Critic validates completeness and consistency
     
     Capabilities: Analyze different sources of information on different topics and consolidate the output.

--- a/demos/kyc-onboarding-bundle/chart/templates/teams/web-research-team.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/teams/web-research-team.yaml
@@ -36,7 +36,7 @@ spec:
     4. Critic reviews quality and source credibility
     5. File Manager saves research results
     
-    When the user message specifies an exact output path (e.g. .../intermediate/web_data_initial_profile.json), the Web Analyst or File Manager MUST call mcp-filesystem-write-file to that path before the task is complete. The task is not done until that file exists. If the Researcher has limited or no tool access, the Analyst should still produce structured JSON from the plan and available context and save it to the specified path.
+    When the user message specifies an exact output path (e.g. .../intermediate/web_data_initial_profile.json), the Web Analyst or File Manager MUST call filesystem-mcp-server-write-file to that path before the task is complete. The task is not done until that file exists. If the Researcher has limited or no tool access, the Analyst should still produce structured JSON from the plan and available context and save it to the specified path.
     
     Limitation: Not capable of reading and extracting information from non-text formats.
   

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-adverse-media-screening.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-adverse-media-screening.yaml
@@ -297,7 +297,7 @@ spec:
                  - high: Government/regulatory websites (SEC, FCA, Companies House), reputable news agencies (Reuters, Bloomberg, BBC, Financial Times, Law360), court records, audited corporate disclosures (annual reports, 10-K filings)
                  - medium: Industry-specific publications, NGO reports, law firm publications, unaudited corporate disclosures (press releases), social media from verified accounts
                  - low: Tabloid media, unverified social media, blogs, anonymous sources, outdated content
-              3. Save findings to a JSON file using the 'mcp-filesystem-write-file' tool
+              3. Save findings to a JSON file using the 'filesystem-mcp-server-write-file' tool
               4. Use the section name as part of the filename: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
               Do NOT add /data or any other prefix to the path.
 
@@ -426,7 +426,7 @@ spec:
 
               The "confidence score" should be 1-10 indicating how confident you are in the classification.
 
-              Update the original file with the relevance classifications using the `mcp-filesystem-write-file` tool.
+              Update the original file with the relevance classifications using the `filesystem-mcp-server-write-file` tool.
               Write back to: {{ "{{inputs.parameters.file-path}}" }}
               Preserve the "subsection" field unchanged.
       outputs:

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-blacklist-sanction-screening.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-blacklist-sanction-screening.yaml
@@ -277,7 +277,7 @@ spec:
               type: agent
               name: consolidation-analyst-agent
             input: |
-              Read the following files using `mcp-filesystem-read-file`:
+              Read the following files using `filesystem-mcp-server-read-file`:
               - Key controllers: {{ "{{inputs.parameters.key-controllers-file}}" }}
               Do NOT add /data or any other prefix to file paths when using MCP tools.
 
@@ -449,7 +449,7 @@ spec:
               Name to screen: {{ "{{inputs.parameters.name}}" }}
               Screening type: {{ "{{inputs.parameters.screening-type}}" }}
 
-              Read the {{ "{{inputs.parameters.screening-type}}" }} file using the `mcp-filesystem-read-file` tool at path: {{ "{{inputs.parameters.document-file}}" }}
+              Read the {{ "{{inputs.parameters.screening-type}}" }} file using the `filesystem-mcp-server-read-file` tool at path: {{ "{{inputs.parameters.document-file}}" }}
               Do NOT add /data or any other prefix to the path.
 
               Search for "{{ "{{inputs.parameters.name}}" }}" in the file content.
@@ -579,7 +579,7 @@ spec:
             input: |
               Current date: {{ "{{inputs.parameters.current-date}}" }}
 
-              STEP 1 - READ FILES: You MUST use the `mcp-filesystem-read-file` tool to read BOTH of these files. Do NOT skip this step. Do NOT add /data or any other prefix to file paths.
+              STEP 1 - READ FILES: You MUST use the `filesystem-mcp-server-read-file` tool to read BOTH of these files. Do NOT skip this step. Do NOT add /data or any other prefix to file paths.
               - Blacklist screening results: {{ "{{inputs.parameters.blacklist-file}}" }}
               - Sanctions screening results: {{ "{{inputs.parameters.sanction-file}}" }}
 
@@ -634,7 +634,7 @@ spec:
               CRITICAL: The top-level key MUST be "screening". Group all blacklist results under "Internal blacklist screening" subsection and all sanction results under "Sanction screening" subsection. Each person's results should be keyed by their name in the "content" object.
               IMPORTANT: Every person from the screening input files MUST appear in BOTH subsections. Do NOT return an empty or partial result.
 
-              You MUST use the `mcp-filesystem-write-file` tool to save the JSON to: {{ "{{inputs.parameters.json-output-file}}" }}
+              You MUST use the `filesystem-mcp-server-write-file` tool to save the JSON to: {{ "{{inputs.parameters.json-output-file}}" }}
               Do NOT add /data or any other prefix to the path.
 
               2. Also create a Markdown report with this EXACT structure:
@@ -669,7 +669,7 @@ spec:
               #### Entities and vessels
               - None (or list if any)
 
-              You MUST use the `mcp-filesystem-write-file` tool to save the Markdown to: {{ "{{inputs.parameters.md-output-file}}" }}
+              You MUST use the `filesystem-mcp-server-write-file` tool to save the Markdown to: {{ "{{inputs.parameters.md-output-file}}" }}
               Do NOT add /data or any other prefix to the path.
 
               After saving both files, confirm the files were written successfully.

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-initial-risk-assessment.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-initial-risk-assessment.yaml
@@ -106,11 +106,11 @@ spec:
             input: |
               You must complete this task yourself and save the output; do not hand off or terminate.
 
-              **CRITICAL RULE — SINGLE FILE OUTPUT:** You MUST produce exactly ONE JSON file containing ALL sections. Do NOT split the output into multiple files. Do NOT create separate files per section. You will call mcp-filesystem-write-file EXACTLY ONCE to write ONE file that contains the complete merged JSON object with all three top-level keys.
+              **CRITICAL RULE — SINGLE FILE OUTPUT:** You MUST produce exactly ONE JSON file containing ALL sections. Do NOT split the output into multiple files. Do NOT create separate files per section. You will call filesystem-mcp-server-write-file EXACTLY ONCE to write ONE file that contains the complete merged JSON object with all three top-level keys.
 
               **CRITICAL — Populate with real data from files.** You MUST read the JSON files from the intermediate directory and **copy the actual values** from them into your output. Do NOT use "NA", "[sender company]", or placeholders for fields that exist in the source files. Only use NA or _Pending_ when a source file is missing or a field is genuinely absent in all sources.
 
-              Step 1 — List and read files: Call mcp-filesystem-list-directory on {{ "{{inputs.parameters.output-base-dir}}" }}/intermediate/ then mcp-filesystem-read-file for each JSON file (inquiry_information.json, web_data_initial_profile.json, government_data_initial_profile.json, kyc_standards.json). Read every file that exists.
+              Step 1 — List and read files: Call filesystem-mcp-server-list-directory on {{ "{{inputs.parameters.output-base-dir}}" }}/intermediate/ then filesystem-mcp-server-read-file for each JSON file (inquiry_information.json, web_data_initial_profile.json, government_data_initial_profile.json, kyc_standards.json). Read every file that exists.
 
               Step 2 — Merge ALL data into ONE single KYC profile JSON object using the exact LegacyX schema below. The final JSON must be a SINGLE object with exactly three top-level keys. **Copy real values** from the files you read.
 
@@ -143,7 +143,7 @@ spec:
               If a file is missing, only then use minimal placeholders for that section. Otherwise **merge and copy the real data** from every file you read.
 
               Step 3 — Write the SINGLE consolidated file:
-              You MUST call mcp-filesystem-write-file EXACTLY ONCE with:
+              You MUST call filesystem-mcp-server-write-file EXACTLY ONCE with:
               - path: {{ "{{inputs.parameters.profile-json}}" }}
               - content: your COMPLETE merged JSON (one object with all three top-level keys)
               Do NOT write multiple files. Do NOT split by section. Do NOT add /data or /mnt prefix to the path. ONE call, ONE file, ALL data.
@@ -171,7 +171,7 @@ spec:
             input: |
               You must complete this task yourself and save the output; do not hand off or terminate.
 
-              Read the KYC profile JSON from: {{ "{{inputs.parameters.profile-json}}" }} using mcp-filesystem-read-file.
+              Read the KYC profile JSON from: {{ "{{inputs.parameters.profile-json}}" }} using filesystem-mcp-server-read-file.
               The profile uses the LegacyX schema: "KYC Standards and Requirements", "Inquiry information", "Initial Profile".
 
               Convert it to Markdown matching the **LegacyX kyc_profile.md** format exactly. **Use the actual values from the JSON** — do not use "NA", "(url)", or placeholders when the JSON has real data. Use the **exact section order** below.
@@ -200,7 +200,7 @@ spec:
               - #### 3.1 Required Documents — bullet list of document items from JSON (each line one item).
               - #### 3.2 Required Checks — bullet list with **bold** check name and description, e.g. **Identity Verification:** Confirm authenticity... (global requirement). Use the exact strings from the JSON; bold the leading check name (e.g. **Key Controllers Verification:**, **Sanctions Screening:**).
 
-              You MUST call mcp-filesystem-write-file with path set to the exact string below (no leading slash, no /data or /mnt prefix) and content set to your full Markdown:
+              You MUST call filesystem-mcp-server-write-file with path set to the exact string below (no leading slash, no /data or /mnt prefix) and content set to your full Markdown:
               {{ "{{inputs.parameters.profile-md}}" }}
     - name: summary-risk-query
       inputs:
@@ -226,9 +226,9 @@ spec:
             input: |
               You must complete this task yourself and save the output; do not hand off or terminate.
 
-              **CRITICAL — FILE OUTPUT REQUIRED:** Your task is NOT complete until you call mcp-filesystem-write-file to save the report. You MUST call mcp-filesystem-write-file with path: {{ "{{inputs.parameters.risk-report}}" }} and content: your full Markdown report. Do NOT just respond with the report text — you MUST save it to the file. Do NOT add /data or /mnt prefix to the path.
+              **CRITICAL — FILE OUTPUT REQUIRED:** Your task is NOT complete until you call filesystem-mcp-server-write-file to save the report. You MUST call filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.risk-report}}" }} and content: your full Markdown report. Do NOT just respond with the report text — you MUST save it to the file. Do NOT add /data or /mnt prefix to the path.
 
-              Read the KYC profile from: {{ "{{inputs.parameters.profile-json}}" }} using mcp-filesystem-read-file.
+              Read the KYC profile from: {{ "{{inputs.parameters.profile-json}}" }} using filesystem-mcp-server-read-file.
 
               Produce an **Initial risk assessment report** in Markdown matching the **LegacyX summary_risk_report.md** format exactly. **Use the actual values from the profile JSON** (company name, address, key individuals, geography, industry, purpose, etc.) — do not use "NA" or placeholders when the JSON contains real data.
 
@@ -263,6 +263,6 @@ spec:
 
               - ### Recommendations: — Bullet list of recommendations (e.g. collect missing documents, complete pending checks, monitor risks). Then on the next line: **Overall Risk Rating**: **<span style="color: orange"> moderate </span>** (or low/green, high/red).
 
-              You MUST call mcp-filesystem-write-file with path set to the exact string below (no leading slash, no /data or /mnt prefix) and content set to your full report:
+              You MUST call filesystem-mcp-server-write-file with path set to the exact string below (no leading slash, no /data or /mnt prefix) and content set to your full report:
               {{ "{{inputs.parameters.risk-report}}" }}
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-kyc-memo.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-kyc-memo.yaml
@@ -89,7 +89,7 @@ spec:
             timeout: 15m
             ttl: 24h
             input: |
-              Read these files using `mcp-filesystem-read-file` (skip any that don't exist):
+              Read these files using `filesystem-mcp-server-read-file` (skip any that don't exist):
               1. Base profile: source_code_files/2-customer-due-diligence/input/kyc_profile.json
               2. Key controllers: source_code_files/2-customer-due-diligence/profile_sections/key_controllers.json
               3. Screening: source_code_files/2-customer-due-diligence/profile_sections/sanction_blacklist_screening.json
@@ -151,9 +151,9 @@ spec:
               For screening results, summarize per-person in tables rather than repeating full justifications.
               Keep the memo under 15,000 characters to ensure it can be saved.
 
-              CRITICAL: You MUST save the file using `mcp-filesystem-write-file` to: {{ "{{inputs.parameters.output-memo}}" }}
+              CRITICAL: You MUST save the file using `filesystem-mcp-server-write-file` to: {{ "{{inputs.parameters.output-memo}}" }}
               Do NOT add /data or any other prefix to the path. The task is NOT complete until the file is written.
-              After writing, verify by reading the file back with `mcp-filesystem-read-file` to confirm it was saved.
+              After writing, verify by reading the file back with `filesystem-mcp-server-read-file` to confirm it was saved.
       outputs:
         parameters:
           - name: response

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-enrichment.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-enrichment.yaml
@@ -93,15 +93,15 @@ spec:
             timeout: 15m
             ttl: 24h
             input: |
-              **CRITICAL: You MUST save your output using mcp-filesystem-write-file. Do NOT just respond with text.**
+              **CRITICAL: You MUST save your output using filesystem-mcp-server-write-file. Do NOT just respond with text.**
 
               Create an initial profile JSON for the company "{{ "{{inputs.parameters.company-name}}" }}". Include: company overview and description, industry and sector, key products/services, recent news or developments, basic financial or operational highlights. Use your knowledge, reasoning, or any available tools to populate the JSON. Structure it per your standard web research output format (business_overview, key_people, sources_consulted, research_status, etc.).
               
               You MUST then save the JSON file:
-              Use mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/web_data_initial_profile.json and content: your full JSON object.
+              Use filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/web_data_initial_profile.json and content: your full JSON object.
               
               OUTPUT FILE PATH (use this exact path): {{ "{{inputs.parameters.output-dir}}" }}/web_data_initial_profile.json
-              Do NOT use /data or /mnt/output prefix. You must actually call mcp-filesystem-write-file—do not just respond with text.
+              Do NOT use /data or /mnt/output prefix. You must actually call filesystem-mcp-server-write-file—do not just respond with text.
     - name: enrich-government-query
       inputs:
         parameters:
@@ -124,13 +124,13 @@ spec:
             timeout: 15m
             ttl: 24h
             input: |
-              **CRITICAL: You MUST save your output using mcp-filesystem-write-file. Do NOT just respond with text.**
+              **CRITICAL: You MUST save your output using filesystem-mcp-server-write-file. Do NOT just respond with text.**
               
               Create a Companies House style JSON for UK company number {{ "{{inputs.parameters.company-number}}" }} (ASSOCIATED BRITISH FOODS PLC). Include: company name and status, registered address, company type, incorporation date, **full list of active officers** (all directors and secretaries — do NOT include only one; include every officer with name, position, appointed_on, nationality, date_of_birth, country_of_residence), SIC codes. Structure it per your standard output (retrieval_metadata, company_profile, officers / current_officers / active_officers array with all entries, persons_with_significant_control, filing_history, kyc_insights, data_quality). Use reasoning and typical Companies House data structure if you do not have live API data; for mock data, generate a complete officers list (e.g. 10+ entries for a large company).
               
               You MUST then save the JSON file:
-              Use mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/government_data_initial_profile.json and content: your full JSON object.
+              Use filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/government_data_initial_profile.json and content: your full JSON object.
               
               OUTPUT FILE PATH (use this exact path): {{ "{{inputs.parameters.output-dir}}" }}/government_data_initial_profile.json
-              Do NOT use /data or /mnt/output prefix. You must actually call mcp-filesystem-write-file—do not just respond with text.
+              Do NOT use /data or /mnt/output prefix. You must actually call filesystem-mcp-server-write-file—do not just respond with text.
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-finalization.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-finalization.yaml
@@ -104,7 +104,7 @@ spec:
 
               Read all JSON files from the profile sections directory: {{ "{{inputs.parameters.profile-sections-dir}}" }}/
               The expected section files are: ownership_structure.json, entities_vessels.json, key_controllers.json, adverse_media_screening.json, sanction_blacklist_screening.json, purpose_of_relationship.json, beneficial_ownership_tree.json.
-              Read each file individually using `mcp-filesystem-read-file`. If a file does not exist, skip it.
+              Read each file individually using `filesystem-mcp-server-read-file`. If a file does not exist, skip it.
 
               Merge the base profile with all profile sections into a single consolidated KYC profile JSON.
               Preserve ALL data — do not summarize or truncate. Include every entry from each section file.
@@ -125,7 +125,7 @@ spec:
               }
 
               CRITICAL: Ensure the output JSON is valid. Every { must have a matching }. Every [ must have a matching ].
-              You MUST use the `mcp-filesystem-write-file` tool to save the merged profile to: {{ "{{inputs.parameters.output-profile-json}}" }}
+              You MUST use the `filesystem-mcp-server-write-file` tool to save the merged profile to: {{ "{{inputs.parameters.output-profile-json}}" }}
               Do NOT add /data or any other prefix to the path.
     - name: profile-json-to-markdown-query
       retryStrategy:
@@ -158,7 +158,7 @@ spec:
               You will create a comprehensive KYC Markdown report by reading individual profile section files.
               Do NOT add /data or any other prefix to file paths when using MCP tools.
 
-              Read these files one by one using `mcp-filesystem-read-file`:
+              Read these files one by one using `filesystem-mcp-server-read-file`:
               1. Base profile: source_code_files/2-customer-due-diligence/input/kyc_profile.json
               2. Key controllers: source_code_files/2-customer-due-diligence/profile_sections/key_controllers.json
               3. Screening: source_code_files/2-customer-due-diligence/profile_sections/sanction_blacklist_screening.json
@@ -219,7 +219,7 @@ spec:
 
               Include ALL data from the JSON — do not summarize or omit entries. Include source attributions and credibility scores where available.
 
-              CRITICAL: You MUST save the file using `mcp-filesystem-write-file`. The task is NOT complete until the file is written.
+              CRITICAL: You MUST save the file using `filesystem-mcp-server-write-file`. The task is NOT complete until the file is written.
               Save to: {{ "{{inputs.parameters.profile-md}}" }}
               Do NOT add /data or any other prefix to the path.
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-initialization.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-initialization.yaml
@@ -87,7 +87,7 @@ spec:
             input: |
               You must complete this task yourself and save the output; do not hand off or terminate.
 
-              Step 1 — Read the email: Use mcp-filesystem-read-file with path: {{ "{{inputs.parameters.input-file}}" }}
+              Step 1 — Read the email: Use filesystem-mcp-server-read-file with path: {{ "{{inputs.parameters.input-file}}" }}
 
               Step 2 — Extract and structure the data in the LegacyX format for inquiry_information.json.
               The output JSON must have exactly this structure (same as LegacyX demo):
@@ -127,5 +127,5 @@ spec:
 
               Extract from the email: sender (contact name), recipient, date, subject, body, company mentions, and any products/purpose/documents mentioned. Use validation status "_Pending_" and validation source "NA" for all fields from the email (no external validation yet). Populate Company details from company names and context in the email.
 
-              Step 3 — Save the JSON (REQUIRED): Call mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-file}}" }} and content: your full JSON. Use the exact path; do NOT add /data or /mnt prefix.
+              Step 3 — Save the JSON (REQUIRED): Call filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-file}}" }} and content: your full JSON. Use the exact path; do NOT add /data or /mnt prefix.
 {{- end }}

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-requirements-and-standards.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-requirements-and-standards.yaml
@@ -130,7 +130,7 @@ spec:
 
               For non-UK geographies, adapt the lists (e.g. replace UK-specific items with local equivalents and annotate with the geography). Use the exact subsection names "Required documents" and "Required checks". Each content item must be a string ending with "(global requirement)" or the appropriate geography (e.g. "(UK requirement)").
 
-              You MUST call mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-file}}" }} and content: your full JSON. Use the exact path; do NOT add /data or /mnt prefix.
+              You MUST call filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-file}}" }} and content: your full JSON. Use the exact path; do NOT add /data or /mnt prefix.
       outputs:
         parameters:
           - name: response

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-entities-vessels.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-entities-vessels.yaml
@@ -596,7 +596,7 @@ spec:
             generateName: doc-extract-
           spec:
             input: |
-              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use mcp-filesystem-read-file on the PDF — it is too large.**
+              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use filesystem-mcp-server-read-file on the PDF — it is too large.**
 
               Step 1 — Extract: Use the pdf-extraction-mcp-extract-pdf-sections tool with these parameters:
               - pdf_path: "{{ "{{inputs.parameters.document-file}}" }}"
@@ -608,7 +608,7 @@ spec:
 
               IMPORTANT: The annual report lists 70+ subsidiary undertakings across multiple pages (typically pages 100-107). Make sure the extraction captures ALL of them.
 
-              Step 3 — Save the extracted information as a JSON file. Use mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
+              Step 3 — Save the extracted information as a JSON file. Use filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
               Do NOT add /data or any other prefix to the path.
 
               The JSON structure should be:
@@ -661,7 +661,7 @@ spec:
 
               Use the 'web-research-mcp-research-ubo-web' tool to research information about the company.
 
-              After collecting the information, save it to a JSON file using the 'mcp-filesystem-write-file' tool.
+              After collecting the information, save it to a JSON file using the 'filesystem-mcp-server-write-file' tool.
               Use the section name as part of the filename: {{ "{{inputs.parameters.output-dir}}" }}/web_{{ "{{inputs.parameters.section}}" }}.json
               Do NOT add /data or any other prefix to the path.
 
@@ -783,7 +783,7 @@ spec:
               Company: {{ "{{inputs.parameters.company-name}}" }}
               Date: {{ "{{inputs.parameters.current-date}}" }}
 
-              **Path convention:** Use the paths below exactly as given with mcp-filesystem-read-file and mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               Read the unconsolidated data from: {{ "{{inputs.parameters.input-file}}" }}
 
@@ -791,7 +791,7 @@ spec:
               Merge findings from both document extraction and web research, removing duplicates and reconciling conflicts.
 
               CRITICAL INSTRUCTIONS:
-              1. First, use mcp-filesystem-read-file to read the unconsolidated data file.
+              1. First, use filesystem-mcp-server-read-file to read the unconsolidated data file.
               2. The file is a JSON array. Each element has a "section" field and a "data" field.
                  - The "data" field may be an ARRAY of subsidiary objects (from PDF extraction) OR an OBJECT with a "subsidiary_entities" key (from web research).
                  - You MUST check BOTH formats and merge ALL entries from ALL array elements.

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-key-controllers.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-key-controllers.yaml
@@ -363,7 +363,7 @@ spec:
             input: |
               Current date: {{ "{{inputs.parameters.current-date}}" }}
 
-              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use mcp-filesystem-read-file on the PDF — it is too large.**
+              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use filesystem-mcp-server-read-file on the PDF — it is too large.**
 
               Step 1 — Extract: Use the pdf-extraction-mcp-extract-pdf-sections tool with these parameters:
               - pdf_path: "{{ "{{inputs.parameters.document-file}}" }}"
@@ -375,7 +375,7 @@ spec:
 
               Important: Only include ACTIVE members. Exclude anyone who has resigned, stepped down, or whose tenure has ended.
 
-              Step 3 — Save the extracted information as a JSON file using mcp-filesystem-write-file.
+              Step 3 — Save the extracted information as a JSON file using filesystem-mcp-server-write-file.
               Save to: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
               Do NOT add /data or any other prefix to the path.
 

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-ownership-structure.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-ownership-structure.yaml
@@ -420,7 +420,7 @@ spec:
             generateName: doc-extract-
           spec:
             input: |
-              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use mcp-filesystem-read-file on the PDF — it is too large.**
+              **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use filesystem-mcp-server-read-file on the PDF — it is too large.**
 
               Step 1 — Scout: Use pdf-extraction-mcp-scout-pdf-for-ownership to find ownership-relevant pages in the PDF at: {{ "{{inputs.parameters.document-file}}" }}
               Use search terms: ["owner", "ownership", "beneficial", "shareholder", "stake", "voting rights", "substantial", "major interest", "Wittington", "Garfield Weston", "share capital"]
@@ -430,7 +430,7 @@ spec:
               Step 3 — Answer this question using the extracted data:
               {{ "{{inputs.parameters.prompt}}" }}
 
-              Step 3 — Save the extracted information as a JSON file. Use mcp-filesystem-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
+              Step 3 — Save the extracted information as a JSON file. Use filesystem-mcp-server-write-file with path: {{ "{{inputs.parameters.output-dir}}" }}/{{ "{{inputs.parameters.section}}" }}.json
               Do NOT add /data or any other prefix to the path.
 
               The JSON MUST follow this exact LegacyX subsection format:
@@ -575,7 +575,7 @@ spec:
               Company: {{ "{{inputs.parameters.company-name}}" }}
               Company Number: {{ "{{inputs.parameters.company-number}}" }}
 
-              **Path convention:** Use the paths below exactly as given with mcp-filesystem-read-file and mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               Read the ownership structure data from: {{ "{{inputs.parameters.input-file}}" }}
 
@@ -641,7 +641,7 @@ spec:
             input: |
               Owner information: {{ "{{inputs.parameters.owner-json}}" }}
 
-              **Path convention:** Use the path below exactly as given with mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the path below exactly as given with filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               **Logic (LegacyX-aligned):** If the owner is an individual (type "individual"), save a minimal JSON with owner_name and empty indirect_owners. If the owner is a company/entity, use perplexity-ask to research beneficial owners, then structure and save the JSON to the path below.
 
@@ -706,7 +706,7 @@ spec:
             generateName: bo-tree-
           spec:
             input: |
-              **Path convention:** Use the paths below exactly as given with mcp-filesystem-read-file and mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               STEP 1: Read the direct beneficial owners from: {{ "{{inputs.parameters.direct-owners-file}}" }}
               STEP 2: Read the indirect beneficial owners from: {{ "{{inputs.parameters.indirect-owners-file}}" }}
@@ -798,7 +798,7 @@ spec:
             input: |
               Company: {{ "{{inputs.parameters.company-name}}" }}
 
-              **Path convention:** Use the paths below exactly as given with mcp-filesystem-read-file and mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               Read the unconsolidated ownership data from: {{ "{{inputs.parameters.input-file}}" }}
 
@@ -889,7 +889,7 @@ spec:
             input: |
               Company: {{ "{{inputs.parameters.company-name}}" }}
 
-              **Path convention:** Use the paths below exactly as given with mcp-filesystem-read-file and mcp-filesystem-write-file. Do NOT add /data or any other prefix.
+              **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
               Read the beneficial ownership tree from: {{ "{{inputs.parameters.input-file}}" }}
 


### PR DESCRIPTION
## Problem
11 of 21 KYC agents were showing as Unavailable in the Ark dashboard with
`Tool not found` errors. All affected agents use filesystem tools.

The templates referenced `mcp-filesystem-*` tool names (e.g.
`mcp-filesystem-read-file`), but the deployed MCPServer is named
`filesystem-mcp-server`, which exposes tools as `filesystem-mcp-server-*`.
The prefix mismatch meant no filesystem tool ever resolved.

Agents that only use `terminate` or `perplexity-ask` were unaffected.

## Fix
Replaced all `mcp-filesystem-<tool>` references with
`filesystem-mcp-server-<tool>` across 15 agent templates, 3 team templates,
and 9 workflow templates — in both the `tools:` spec sections (which
determine agent availability) and prompt text (which guides the LLM at
runtime). Kubernetes volume names (`mcp-filesystem-volume`) are unchanged.

## Test plan
- [ ] `make upgrade` completes successfully
- [ ] All 21 KYC agents show Available in the Ark dashboard
- [ ] `kubectl get agent -n default -l bundle=kyc-onboarding` shows all True