### PR TITLE
fix(executors/claude-agent-sdk): stream token-level deltas via includ…

### DIFF
--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 from ark_sdk.executor import BaseExecutor, MCPServerConfig, Message
 from ark_sdk.executor_app import is_otel_enabled
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, list_sessions
-from claude_agent_sdk.types import AssistantMessage, TextBlock
+from claude_agent_sdk.types import StreamEvent
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +127,7 @@ class ClaudeAgentExecutor(BaseExecutor):
             cwd=str(session_dir),
             permission_mode="bypassPermissions",
             env=env,
+            include_partial_messages=True,
             **mcp_kwargs,
             **resume_kwargs,
         )
@@ -137,10 +138,14 @@ class ClaudeAgentExecutor(BaseExecutor):
             async with ClaudeSDKClient(options=options) as client:
                 await client.query(user_input)
                 async for message in client.receive_response():
-                    if isinstance(message, AssistantMessage):
-                        for block in message.content:
-                            if isinstance(block, TextBlock) and block.text:
-                                await self.stream_chunk(block.text)
+                    if isinstance(message, StreamEvent):
+                        event = message.event or {}
+                        if event.get("type") == "content_block_delta":
+                            delta = event.get("delta") or {}
+                            if delta.get("type") == "text_delta":
+                                text = delta.get("text")
+                                if text:
+                                    await self.stream_chunk(text)
                     if hasattr(message, "result") and message.result:
                         result_text = message.result
 

--- a/executors/claude-agent-sdk/tests/conftest.py
+++ b/executors/claude-agent-sdk/tests/conftest.py
@@ -51,6 +51,13 @@ def _build_stub() -> None:
         structured_output: Any = None
 
     @dataclass
+    class StreamEvent:
+        uuid: str = ""
+        session_id: str = ""
+        event: dict = field(default_factory=dict)
+        parent_tool_use_id: Optional[str] = None
+
+    @dataclass
     class ClaudeAgentOptions:
         model: str = ""
         cwd: str = "."
@@ -59,6 +66,7 @@ def _build_stub() -> None:
         mcp_servers: Optional[dict] = None
         allowed_tools: Optional[list] = None
         resume: Optional[str] = None
+        include_partial_messages: bool = False
 
     class ClaudeSDKClient:
         def __init__(self, options=None):
@@ -87,6 +95,7 @@ def _build_stub() -> None:
     sdk_types.ToolResultBlock = ToolResultBlock
     sdk_types.AssistantMessage = AssistantMessage
     sdk_types.ResultMessage = ResultMessage
+    sdk_types.StreamEvent = StreamEvent
     sdk_types.ClaudeAgentOptions = ClaudeAgentOptions
 
     sdk = types.ModuleType("claude_agent_sdk")

--- a/executors/claude-agent-sdk/tests/test_streaming.py
+++ b/executors/claude-agent-sdk/tests/test_streaming.py
@@ -1,9 +1,9 @@
 """Tests for broker streaming via stream_chunk in ClaudeAgentExecutor."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from claude_agent_sdk.types import AssistantMessage, TextBlock, ThinkingBlock
+from claude_agent_sdk.types import StreamEvent
 from ark_sdk.executor import Message
 from claude_agent_executor.executor import ClaudeAgentExecutor
 
@@ -25,22 +25,40 @@ def _request(conversation_id="conv-1", user_input="hello"):
     return request
 
 
-def _make_assistant_message(*texts):
-    return AssistantMessage(
-        content=[TextBlock(text=t) for t in texts],
-        model="claude-sonnet-4-20250514",
-    )
+def _text_delta(text):
+    return StreamEvent(event={"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}})
 
 
-def _make_result_message(result="final answer"):
+def _result_message(result="final answer"):
     msg = MagicMock()
     msg.result = result
     return msg
 
 
+def _fake_client(*events):
+    class FakeClient:
+        def __init__(self, options=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def query(self, prompt):
+            pass
+
+        async def receive_response(self):
+            for event in events:
+                yield event
+
+    return FakeClient
+
+
 class TestStreaming:
     @pytest.mark.asyncio
-    async def test_stream_chunk_called_for_assistant_text_blocks(self, tmp_path):
+    async def test_stream_chunk_called_for_text_deltas(self, tmp_path):
         executor = ClaudeAgentExecutor()
         chunks = []
 
@@ -49,22 +67,11 @@ class TestStreaming:
 
         executor.stream_chunk = capture_chunk
 
-        class FakeClient:
-            def __init__(self, options=None):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-            async def query(self, prompt):
-                pass
-
-            async def receive_response(self):
-                yield _make_assistant_message("Hello ", "world")
-                yield _make_result_message("Hello world")
+        FakeClient = _fake_client(
+            _text_delta("Hello "),
+            _text_delta("world"),
+            _result_message("Hello world"),
+        )
 
         with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
              patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
@@ -74,7 +81,7 @@ class TestStreaming:
         assert result == [Message(role="assistant", content="Hello world", name="test-agent")]
 
     @pytest.mark.asyncio
-    async def test_non_text_blocks_not_streamed(self, tmp_path):
+    async def test_non_text_delta_events_not_streamed(self, tmp_path):
         executor = ClaudeAgentExecutor()
         chunks = []
 
@@ -83,29 +90,14 @@ class TestStreaming:
 
         executor.stream_chunk = capture_chunk
 
-        class FakeClient:
-            def __init__(self, options=None):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-            async def query(self, prompt):
-                pass
-
-            async def receive_response(self):
-                msg = AssistantMessage(
-                    content=[
-                        ThinkingBlock(thinking="internal thought", signature="sig"),
-                        TextBlock(text="visible text"),
-                    ],
-                    model="claude-sonnet-4-20250514",
-                )
-                yield msg
-                yield _make_result_message("visible text")
+        FakeClient = _fake_client(
+            StreamEvent(event={"type": "message_start"}),
+            StreamEvent(event={"type": "content_block_start", "content_block": {"type": "tool_use"}}),
+            StreamEvent(event={"type": "content_block_delta", "delta": {"type": "input_json_delta", "partial_json": "{}"}}),
+            _text_delta("visible text"),
+            StreamEvent(event={"type": "content_block_stop"}),
+            _result_message("visible text"),
+        )
 
         with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
              patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
@@ -114,7 +106,7 @@ class TestStreaming:
         assert chunks == ["visible text"]
 
     @pytest.mark.asyncio
-    async def test_no_assistant_messages_no_stream_chunks(self, tmp_path):
+    async def test_no_stream_events_no_stream_chunks(self, tmp_path):
         executor = ClaudeAgentExecutor()
         chunks = []
 
@@ -123,21 +115,7 @@ class TestStreaming:
 
         executor.stream_chunk = capture_chunk
 
-        class FakeClient:
-            def __init__(self, options=None):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-            async def query(self, prompt):
-                pass
-
-            async def receive_response(self):
-                yield _make_result_message("done")
+        FakeClient = _fake_client(_result_message("done"))
 
         with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
              patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
@@ -146,7 +124,7 @@ class TestStreaming:
         assert chunks == []
 
     @pytest.mark.asyncio
-    async def test_empty_text_blocks_not_streamed(self, tmp_path):
+    async def test_empty_text_deltas_not_streamed(self, tmp_path):
         executor = ClaudeAgentExecutor()
         chunks = []
 
@@ -155,22 +133,10 @@ class TestStreaming:
 
         executor.stream_chunk = capture_chunk
 
-        class FakeClient:
-            def __init__(self, options=None):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-            async def query(self, prompt):
-                pass
-
-            async def receive_response(self):
-                yield _make_assistant_message("")
-                yield _make_result_message("done")
+        FakeClient = _fake_client(
+            _text_delta(""),
+            _result_message("done"),
+        )
 
         with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
              patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):


### PR DESCRIPTION
…e_partial_messages

## Summary
- Enable ClaudeAgentOptions.include_partial_messages so the SDK yields StreamEvent partials
- Forward text_delta events from content_block_delta to stream_chunk() (token-level streaming)
- Drop the block-level AssistantMessage/TextBlock branch (would double-emit once partials are on)
- Update tests and conftest stub to drive StreamEvent sequences instead of complete AssistantMessages

Verified in-cluster: 5-sentence prompt now produces 21 broker chunks over ~12s; previously arrived as a single chunk at completion.