### PR TITLE
feat(kyc-onboarding-bundle): add session and conversation IDs to workflow queries

### DIFF
--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-adverse-media-screening.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-adverse-media-screening.yaml
@@ -276,6 +276,8 @@ spec:
           metadata:
             generateName: web-data-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: team
               name: web-research-team
@@ -391,6 +393,8 @@ spec:
           metadata:
             generateName: relevance-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: relevance-classification-agent
@@ -488,6 +492,8 @@ spec:
           metadata:
             generateName: summarize-ams-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-assess-purpose-of-relationship.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-assess-purpose-of-relationship.yaml
@@ -100,6 +100,8 @@ spec:
           metadata:
             generateName: purpose-relationship-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-blacklist-sanction-screening.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-blacklist-sanction-screening.yaml
@@ -273,6 +273,8 @@ spec:
           metadata:
             generateName: screening-list-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -442,6 +444,8 @@ spec:
           metadata:
             generateName: screen-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -573,6 +577,8 @@ spec:
           metadata:
             generateName: summarize-sanctions-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-initial-risk-assessment.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-initial-risk-assessment.yaml
@@ -97,6 +97,8 @@ spec:
           metadata:
             generateName: initial-risk-consolidate-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -162,6 +164,8 @@ spec:
           metadata:
             generateName: initial-risk-json2md-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -217,6 +221,8 @@ spec:
           metadata:
             generateName: initial-risk-summary-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: summary-assessment-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-kyc-memo.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-kyc-memo.yaml
@@ -82,6 +82,8 @@ spec:
           metadata:
             generateName: kyc-memo-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: summary-assessment-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-enrichment.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-enrichment.yaml
@@ -86,6 +86,8 @@ spec:
           metadata:
             generateName: profile-enrich-web-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: {{ .Values.agents.webAnalyst.name }}
@@ -117,6 +119,8 @@ spec:
           metadata:
             generateName: profile-enrich-gov-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: {{ .Values.agents.chAnalyst.name }}

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-finalization.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-finalization.yaml
@@ -92,6 +92,8 @@ spec:
           metadata:
             generateName: profile-finalize-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -148,6 +150,8 @@ spec:
           metadata:
             generateName: profile-json2md-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: summary-assessment-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-initialization.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-profile-initialization.yaml
@@ -78,6 +78,8 @@ spec:
           metadata:
             generateName: profile-init-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-requirements-and-standards.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-requirements-and-standards.yaml
@@ -78,6 +78,8 @@ spec:
           metadata:
             generateName: kyc-standards-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-entities-vessels.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-entities-vessels.yaml
@@ -595,6 +595,8 @@ spec:
           metadata:
             generateName: doc-extract-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use filesystem-mcp-server-read-file on the PDF — it is too large.**
 
@@ -651,6 +653,8 @@ spec:
           metadata:
             generateName: web-data-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: team
               name: web-research-team
@@ -775,6 +779,8 @@ spec:
           metadata:
             generateName: consolidate-ev-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-key-controllers.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-key-controllers.yaml
@@ -357,6 +357,8 @@ spec:
           metadata:
             generateName: doc-extract-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: rag-agent
@@ -442,6 +444,8 @@ spec:
           metadata:
             generateName: web-data-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: team
               name: web-research-team
@@ -673,6 +677,8 @@ spec:
           metadata:
             generateName: consolidate-kc-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent

--- a/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-ownership-structure.yaml
+++ b/demos/kyc-onboarding-bundle/chart/templates/workflows/lx-retrieve-ownership-structure.yaml
@@ -419,6 +419,8 @@ spec:
           metadata:
             generateName: doc-extract-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               **CRITICAL: Use pdf-extraction-mcp tools to analyze the PDF. Do NOT use filesystem-mcp-server-read-file on the PDF — it is too large.**
 
@@ -571,6 +573,8 @@ spec:
           metadata:
             generateName: direct-bo-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               Company: {{ "{{inputs.parameters.company-name}}" }}
               Company Number: {{ "{{inputs.parameters.company-number}}" }}
@@ -638,6 +642,8 @@ spec:
           metadata:
             generateName: indirect-bo-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               Owner information: {{ "{{inputs.parameters.owner-json}}" }}
 
@@ -705,6 +711,8 @@ spec:
           metadata:
             generateName: bo-tree-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               **Path convention:** Use the paths below exactly as given with filesystem-mcp-server-read-file and filesystem-mcp-server-write-file. Do NOT add /data or any other prefix.
 
@@ -791,6 +799,8 @@ spec:
           metadata:
             generateName: consolidate-ownership-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             target:
               type: agent
               name: consolidation-analyst-agent
@@ -886,6 +896,8 @@ spec:
           metadata:
             generateName: diagram-
           spec:
+            sessionId: "{{ "session-{{workflow.uid}}" }}"
+            conversationId: "{{ "conversation-{{workflow.uid}}" }}"
             input: |
               Company: {{ "{{inputs.parameters.company-name}}" }}
 


### PR DESCRIPTION
## Summary
- Adds `sessionId` and `conversationId` to all 29 Query manifests across the 12 KYC `WorkflowTemplate`s
- Both IDs are derived from Argo's `{{workflow.uid}}` so each workflow run gets a fresh, distinct pair while all queries within one run share the same pair
- Prefixed differently (`session-…` vs `conversation-…`) so they remain visually distinguishable in `kubectl get queries` and the Ark Dashboard

## Why
Without these fields, agent/team interactions across a single workflow run can't be correlated as one tracked session or memory-linked conversation. Setting them per-run unlocks two things at once: traceability (`sessionId`) and conversation-memory continuity across the agents in a run (`conversationId`), without any cross-run leakage.

## Test plan
- [x] `helm template chart/ --set argoWorkflows.rbac.enabled=true --set dataSeeder.enabled=true` renders cleanly with exactly 29 `sessionId:` and 29 `conversationId:` lines (matches the Query manifest count)
- [x] `helm upgrade` applies cleanly to a running cluster (revision bumps without errors)
- [x] After upgrade, `kubectl get workflowtemplate lx-profile-initialization -n default -o yaml` shows the new fields under `spec.templates[].resource.manifest.spec`
- [ ] Submit a workflow and confirm the resulting Query CRs have non-empty `spec.sessionId` and `spec.conversationId`, with all queries in a single run sharing the same values
- [ ] Confirm a second run produces a different pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)