### PR TITLE
fix(openai-responses): pin kubernetes<36.0.0 to fix system:anonymous auth failure

### DIFF
--- a/executors/openai-responses/pyproject.toml
+++ b/executors/openai-responses/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "openinference-instrumentation-openai",
     "opentelemetry-exporter-otlp-proto-http",
     "urllib3>=2.6.0",
+    "kubernetes>=32.0.0,<36.0.0",
     "a2a-sdk[http-server]>=0.3.0",
 ]
 classifiers = [


### PR DESCRIPTION

kubernetes==36.0.0 (released 2026-05-20) introduced a breaking change: auth_settings() now looks for api_key['BearerToken'] but load_incluster_config() still sets api_key['authorization']. The key mismatch means no Authorization header is ever sent, so every Kubernetes API call is rejected as system:anonymous (403 Forbidden). This caused agents using the responses executor to hang.

This is the same issue fixed in ark-api and ark-mcp via mckinsey/agents-at-scale-ark#2196. Pin kubernetes>=32.0.0,<36.0.0 here for the same reason.