### PR TITLE
feat(cobol-demo): run modernization workflow end-to-end

### DIFF
--- a/demos/cobol-modernization-bundle/chart/templates/agents/cobol-pseudocode-documenter.yaml
+++ b/demos/cobol-modernization-bundle/chart/templates/agents/cobol-pseudocode-documenter.yaml
@@ -87,8 +87,8 @@ spec:
 
     Save the final documentation as a markdown file using the write-file tool:
     - This should be encapsulated in a SINGLE markdown file
-    - Save to the output folder specified
-    - Keep the original filename but change the extension to `.md`
+    - Use the EXACT full output path specified in the task input (e.g., output/pseudocode/filename.cbl.md)
+    - Do NOT shorten the path — use the complete path including all directories as given in the task
 
     ## Example Output Structure
 
@@ -125,7 +125,7 @@ spec:
     2. Analyse the code structure and logic
     3. Create documentation with ALL required sections
     4. Ensure pseudo-code follows ALL guidelines
-    5. Save to the specified output path with .md extension using write-file tool
+    5. Save to the EXACT full path specified in the task (including all directories) using write-file tool
 
     Always save your output - do not just respond with text.
 {{- end }}

--- a/demos/cobol-modernization-bundle/chart/templates/agents/pseudo-python-modernizer.yaml
+++ b/demos/cobol-modernization-bundle/chart/templates/agents/pseudo-python-modernizer.yaml
@@ -107,8 +107,7 @@ spec:
 
     - Save the final code using the write-file tool
     - Save as a SINGLE Python script (.py file)
-    - Keep the original filename but change extension to `.py`
-    - Save to the specified output folder
+    - Use the EXACT full output path specified in the task input (including all directories)
 
     ## Output Format
 
@@ -147,7 +146,7 @@ spec:
     2. Read the modernisation plan (if provided) for naming conventions
     3. Convert to Python/PySpark code following ALL requirements above
     4. Self-review the code for completeness and correctness
-    5. Save to the specified output path with .py extension using write-file tool
+    5. Save to the EXACT full path specified in the task (including all directories) using write-file tool
 
     Always save your output - do not just respond with text.
 {{- end }}

--- a/demos/cobol-modernization-bundle/chart/templates/rbac.yaml
+++ b/demos/cobol-modernization-bundle/chart/templates/rbac.yaml
@@ -46,7 +46,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argo-workflows-edit
+  name: argo-aggregate-to-edit
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-argo-workflow

--- a/demos/cobol-modernization-bundle/chart/templates/workflow-template.yaml
+++ b/demos/cobol-modernization-bundle/chart/templates/workflow-template.yaml
@@ -27,6 +27,13 @@ spec:
   templates:
     - name: main
       steps:
+        - - name: init-output-dirs
+            template: init-output-dirs
+            arguments:
+              parameters:
+                - name: output-dir
+                  value: "{{ "{{workflow.parameters.output-dir}}" }}"
+
         - - name: list-cobol-files
             template: list-files
             arguments:
@@ -57,7 +64,9 @@ spec:
             withParam: "{{ "{{steps.list-cobol-files.outputs.parameters.files}}" }}"
 
         - - name: transcribe-audio
-            template: query-agent-with-retry
+            template: query-agent
+            continueOn:
+              failed: true
             arguments:
               parameters:
                 - name: agent-name
@@ -144,14 +153,26 @@ spec:
                 - name: workflow-status
                   value: "{{ "{{workflow.status}}" }}"
 
+    - name: init-output-dirs
+      inputs:
+        parameters:
+          - name: output-dir
+      script:
+        image: curlimages/curl:latest
+        command: [sh]
+        source: |
+          set -e
+          OUTPUT_DIR="{{ "{{inputs.parameters.output-dir}}" }}"
+          for subdir in pseudocode transcription diagrams python; do
+            echo "placeholder" > /tmp/placeholder
+            curl -sf -X POST \
+              -F "file=@/tmp/placeholder;filename=.gitkeep" \
+              -F "prefix=${OUTPUT_DIR}/${subdir}/" \
+              "http://file-gateway-api/files" || echo "Warning: could not create ${subdir} dir"
+          done
+          echo "Output directories initialized"
+
     - name: list-files
-      retryStrategy:
-        limit: 3
-        retryPolicy: "Always"
-        backoff:
-          duration: "15s"
-          factor: 2
-          maxDuration: "2m"
       inputs:
         parameters:
           - name: directory
@@ -162,40 +183,17 @@ spec:
         source: |
           set -e
 
-          QUERY_NAME="list-files-$(date +%s%N)"
+          DIRECTORY="{{ "{{inputs.parameters.directory}}" }}"
+          PATTERN="{{ "{{inputs.parameters.pattern}}" }}"
+          EXT="${PATTERN#\*}"
 
-          cat > /tmp/query.yaml <<EOF
-          apiVersion: ark.mckinsey.com/v1alpha1
-          kind: Query
-          metadata:
-            name: $QUERY_NAME
-          spec:
-            input: |
-              List all files in the directory: {{ "{{inputs.parameters.directory}}" }}
-              Return ONLY the filenames (not full paths) that match pattern: {{ "{{inputs.parameters.pattern}}" }}
-              Format the output as a JSON array of strings, like: ["file1.cbl", "file2.cbl"]
-            target:
-              type: agent
-              name: cobol-pseudocode-documenter
-            serviceAccount: {{ .Release.Name }}-argo-workflow
-            timeout: 5m
-            ttl: 1h
-          EOF
+          curl -sf "http://file-gateway-api/files?prefix=${DIRECTORY}/" > /tmp/gateway-response.json
 
-          kubectl apply -n {{ .Release.Namespace }} -f /tmp/query.yaml
-          kubectl wait --for=condition=Completed --timeout=5m -n {{ .Release.Namespace }} query/$QUERY_NAME || true
-
-          kubectl get query $QUERY_NAME -n {{ .Release.Namespace }} -o json > /tmp/query.json
-
-          CONTENT=$(jq -r '.status.response.content // .status.responses[0].content // empty' /tmp/query.json)
-
-          echo "$CONTENT" | grep -oE '\[("[^"]*"(,\s*"[^"]*")*)?\]' | head -1 > /tmp/files.json
-
-          jq -c '.' /tmp/files.json > /tmp/validated.json 2>/dev/null && mv /tmp/validated.json /tmp/files.json || echo '[]' > /tmp/files.json
+          jq -c '[.files[].key | split("/") | last | select(endswith("'"$EXT"'"))]' /tmp/gateway-response.json > /tmp/files.json
 
           FILE_COUNT=$(jq '. | length' /tmp/files.json)
           if [ "$FILE_COUNT" -eq 0 ]; then
-            echo "Error: No files found matching pattern '{{ "{{inputs.parameters.pattern}}" }}' in directory '{{ "{{inputs.parameters.directory}}" }}'"
+            echo "Error: No files found matching pattern '${PATTERN}' in directory '${DIRECTORY}'"
             exit 1
           fi
 
@@ -206,28 +204,6 @@ spec:
           - name: files
             valueFrom:
               path: /tmp/files.json
-
-    - name: query-agent-with-retry
-      retryStrategy:
-        limit: 3
-        retryPolicy: "Always"
-        backoff:
-          duration: "30s"
-          factor: 2
-          maxDuration: "5m"
-      inputs:
-        parameters:
-          - name: agent-name
-          - name: task-description
-      steps:
-        - - name: run
-            template: query-agent
-            arguments:
-              parameters:
-                - name: agent-name
-                  value: "{{ "{{inputs.parameters.agent-name}}" }}"
-                - name: task-description
-                  value: "{{ "{{inputs.parameters.task-description}}" }}"
 
     - name: query-agent
       inputs:
@@ -240,7 +216,8 @@ spec:
         source: |
           set -eux
 
-          QUERY_NAME="cobol-mod-{{ "{{workflow.name}}" }}-{{ "{{inputs.parameters.agent-name}}" }}-$(date +%s%N)"
+          POD_SUFFIX=$(hostname | sed 's/.*-//')
+          QUERY_NAME="cobol-mod-{{ "{{workflow.name}}" }}-{{ "{{inputs.parameters.agent-name}}" }}-${POD_SUFFIX}"
           AGENT_NAME="{{ "{{inputs.parameters.agent-name}}" }}"
 
           cat > /tmp/task-description.txt <<'TASKEOF'
@@ -267,9 +244,15 @@ spec:
             ttl: 24h
           EOF
 
-          kubectl apply -n {{ .Release.Namespace }} -f /tmp/query.yaml
+          kubectl create -n {{ .Release.Namespace }} -f /tmp/query.yaml
 
-          kubectl wait --for=condition=Completed --timeout=35m -n {{ .Release.Namespace }} query/$QUERY_NAME || true
+          for i in $(seq 1 420); do
+            PHASE=$(kubectl get query $QUERY_NAME -n {{ .Release.Namespace }} -o jsonpath='{.status.phase}' 2>/dev/null)
+            if [ "$PHASE" = "done" ] || [ "$PHASE" = "error" ]; then
+              break
+            fi
+            sleep 5
+          done
 
           kubectl get query $QUERY_NAME -n {{ .Release.Namespace }} -o json > /tmp/query.json
           PHASE=$(jq -r '.status.phase' /tmp/query.json)

--- a/mcps/speech-mcp-server/chart/templates/deployment.yaml
+++ b/mcps/speech-mcp-server/chart/templates/deployment.yaml
@@ -16,6 +16,25 @@ spec:
     spec:
       serviceAccountName: {{ include "speech-mcp.fullname" . }}-sa
       automountServiceAccountToken: false
+      {{- if and .Values.prefetch.enabled .Values.prefetch.files }}
+      initContainers:
+        - name: prefetch-files
+          image: {{ .Values.prefetch.image | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              BASE="{{ .Values.env.baseDateDir }}"
+              {{- range .Values.prefetch.files }}
+              mkdir -p "$BASE/$(dirname "{{ . }}")"
+              curl -sf "{{ $.Values.prefetch.fileGatewayUrl }}/files/{{ . }}/download" -o "$BASE/{{ . }}"
+              echo "Prefetched: {{ . }}"
+              {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- end }}
       containers:
         - name: speech-mcp
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -53,5 +72,9 @@ spec:
               mountPath: /data
       volumes:
         - name: data
+          {{- if .Values.dataVolume.claimName }}
           persistentVolumeClaim:
-            claimName: {{ .Values.dataVolume.claimName | default "file-gateway-storage" }}
+            claimName: {{ .Values.dataVolume.claimName }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/mcps/speech-mcp-server/chart/values.yaml
+++ b/mcps/speech-mcp-server/chart/values.yaml
@@ -25,6 +25,12 @@ resources:
 dataVolume:
   claimName: ""
 
+prefetch:
+  enabled: false
+  fileGatewayUrl: "http://file-gateway-api"
+  image: "curlimages/curl:latest"
+  files: []
+
 env:
   baseDateDir: /data/aas-files
   cacheDir: /data/whisper-cache


### PR DESCRIPTION
Related to [issue 1911](https://github.com/orgs/mckinsey/projects/10/views/1?pane=issue&itemId=176720675&issue=mckinsey%7Cagents-at-scale-ark%7C1911)

# Summary

Make the COBOL modernization demo produce all outputs end-to-end and render correctly in the dashboard.

- Add init-output-dirs step so agents write into output/{pseudocode, transcription,diagrams,python}/ instead of scattering to the root (file-gateway write does not create parent directories)
- Drop retryStrategy from main-chain steps: the Retry nodes Argo inserts break the dashboard's step view, hiding every step after the first
- Make Query names unique via the pod hostname and use kubectl create: date +%s%N collapses to seconds on busybox, colliding in parallel fan-out
- Poll .status.phase instead of kubectl wait --for=condition, which matched the wrong Query and is unreliable for the Ark Query CRD
- Fix RBAC roleRef to the standard argo-aggregate-to-edit ClusterRole
- Point the pseudocode and python agents at the exact full output path
- speech-mcp-server: add optional prefetch init-container + emptyDir fallback so audio is fetched over HTTP, decoupling it from the single-AZ RWO PVC (disabled by default)