### PR TITLE
fix: workflow session IDs (onboarding + cobol), onboarding RBAC and query polling

### DIFF
--- a/demos/cobol-modernization-bundle/chart/templates/workflow-template.yaml
+++ b/demos/cobol-modernization-bundle/chart/templates/workflow-template.yaml
@@ -234,6 +234,7 @@ spec:
               agent: "$AGENT_NAME"
               use-case: cobol-modernization
           spec:
+            sessionId: "{{ "{{workflow.name}}" }}"
             input: |
           $(cat /tmp/task-description.txt | sed 's/^/      /')
             target:

--- a/demos/onboarding-guide-bundle/chart/templates/rbac.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/rbac.yaml
@@ -40,7 +40,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argo-workflows-edit
+  name: argo-aggregate-to-edit
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.argoWorkflows.serviceAccountName }}

--- a/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
@@ -208,11 +208,11 @@ spec:
             }' | kubectl apply -f -
 
           # Wait until the query leaves the 'running' phase. If it errored, fail this step so Argo surfaces it.
-          until [ "$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)" != "running" ] \
-                && [ -n "$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)" ]; do
+          while true; do
+            PHASE=$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}' 2>/dev/null)
+            [ -n "$PHASE" ] && [ "$PHASE" != "running" ] && break
             sleep 3
           done
-          PHASE=$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.phase}')
           DURATION=$(kubectl get query "$SAFE_NAME" -o jsonpath='{.status.duration}')
           echo ""
           echo "query $SAFE_NAME finished phase=$PHASE duration=$DURATION"

--- a/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
+++ b/demos/onboarding-guide-bundle/chart/templates/workflow-template.yaml
@@ -201,6 +201,7 @@ spec:
               },
               spec: {
                 input: $input,
+                sessionId: $wf,
                 target: {name: $target_name, type: $target_type},
                 timeout: $timeout,
                 ttl: "1h"


### PR DESCRIPTION
## Summary
- **Workflow session IDs (onboarding + cobol)**: set `spec.sessionId` to the Argo workflow name on workflow-created Queries. Without it the controller fell back to each Query's UID, so every step became its own one-query "session" in session-history; now all steps of a run group under one conversation.
- **Argo RBAC (onboarding)**: bind the workflow ServiceAccount to ClusterRole `argo-aggregate-to-edit` (the name the official Argo Helm chart creates) instead of the non-existent `argo-workflows-edit`. Matches `cobol-modernization-bundle`.
- **Query polling race (onboarding)**: read `.status.phase` once per loop iteration instead of via two separate `kubectl` calls, which could exit while the query was still `running` and fail the step intermittently.