### PR TITLE
feat: publish read-only kubernetes-mcp-server as a marketplace mcp

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -105,6 +105,19 @@
         }
       ]
     },
+    "mcps/kubernetes-mcp-server": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm",
+      "package-name": "kubernetes-mcp-server",
+      "extra-files": [
+        "chart/Chart.yaml",
+        {
+          "type": "yaml",
+          "path": "chart/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
+    },
     "demos/cobol-modernization-bundle": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "helm",

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -10,6 +10,7 @@
   "services/file-gateway": "0.1.8",
   "services/file-gateway/services/file-api": "0.1.3",
   "mcps/filesystem-mcp-server": "0.1.57",
+  "mcps/kubernetes-mcp-server": "0.1.0",
   "demos/cobol-modernization-bundle": "0.1.7",
   "executors/langchain": "0.1.7",
   "executors/claude-agent-sdk": "0.1.11",

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -61,6 +61,8 @@ jobs:
           - { name: file-gateway, path: services/file-gateway, namespace: default, run-deployment-test: false }
           # disable filesystem-mcp-server deployment tests for PRs to avoid hitting 5m limit
           - { name: filesystem-mcp-server, path: mcps/filesystem-mcp-server, namespace: default, run-deployment-test: false }
+          # disable kubernetes-mcp-server deployment tests for PRs to avoid hitting 5m limit
+          - { name: kubernetes-mcp-server, path: mcps/kubernetes-mcp-server, namespace: default, run-deployment-test: false }
           # disable cobol-modernization-bundle deployment tests for PRs to avoid hitting 5m limit
           - { name: cobol-modernization-bundle, path: demos/cobol-modernization-bundle, namespace: default, run-deployment-test: false }
           # disable executor-langchain deployment tests for PRs to avoid hitting 5m limit
@@ -183,6 +185,7 @@ jobs:
           - { name: kyc-demo-bundle, path: demos/kyc-demo-bundle, namespace: default }
           - { name: file-gateway, path: services/file-gateway, namespace: default }
           - { name: filesystem-mcp-server, path: mcps/filesystem-mcp-server, namespace: default }
+          - { name: kubernetes-mcp-server, path: mcps/kubernetes-mcp-server, namespace: default }
           - { name: cobol-modernization-bundle, path: demos/cobol-modernization-bundle, namespace: default }
           - { name: executor-langchain, path: executors/langchain, namespace: default }
           - { name: executor-claude-agent-sdk, path: executors/claude-agent-sdk, namespace: default }

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -73,6 +73,8 @@ jobs:
           - { name: file-gateway, path: services/file-gateway, namespace: default, run-deployment-test: false }
           # disable filesystem-mcp-server deployment tests for PRs to avoid hitting 5m limit
           - { name: filesystem-mcp-server, path: mcps/filesystem-mcp-server, namespace: default, run-deployment-test: false }
+          # disable kubernetes-mcp-server deployment tests for PRs to avoid hitting 5m limit
+          - { name: kubernetes-mcp-server, path: mcps/kubernetes-mcp-server, namespace: default, run-deployment-test: false }
           # disable cobol-modernization-bundle deployment tests for PRs to avoid hitting 5m limit
           - { name: cobol-modernization-bundle, path: demos/cobol-modernization-bundle, namespace: default, run-deployment-test: false }
           # disable executor-langchain deployment tests for PRs to avoid hitting 5m limit

--- a/docs/content/mcps/_meta.js
+++ b/docs/content/mcps/_meta.js
@@ -5,4 +5,5 @@ export default {
   'web-research-mcp': 'Web Research MCP',
   'perplexity-ask-mcp': 'Perplexity Ask MCP',
   'companies-house-mcp': 'Companies House MCP',
+  'kubernetes-mcp-server': 'Kubernetes MCP Server',
 }

--- a/docs/content/mcps/kubernetes-mcp-server.mdx
+++ b/docs/content/mcps/kubernetes-mcp-server.mdx
@@ -1,0 +1,68 @@
+---
+title: Kubernetes MCP Server
+description: Read-only kubernetes-mcp-server registered with Ark for grounding agents on cluster resources
+---
+
+# Kubernetes MCP Server
+
+The Kubernetes MCP Server is a read-only [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) registered with Ark. It grounds agents on live cluster resources without granting any write access. The chart wraps the upstream chart and layers Ark configuration: read-only mode, namespace-scoped read-only RBAC, a `localhost-gateway` HTTPRoute, and an Ark `MCPServer` registration.
+
+## Available Tools
+
+In read-only mode the server exposes resource inspection tools (prefixed with `kubernetes-mcp-server-`):
+
+- `kubernetes-mcp-server-resources-list` - List resources of a given kind
+- `kubernetes-mcp-server-resources-get` - Get a specific resource
+
+## What it deploys
+
+- The upstream `kubernetes-mcp-server` chart from `oci://ghcr.io/containers/charts`, in read-only mode.
+- A namespace-scoped read-only `Role`/`RoleBinding` (`ark-reader`) granting `get`/`list`/`watch` on `ark.mckinsey.com` resources and `argoproj.io` workflows / workflow templates.
+- A `localhost-gateway` `HTTPRoute`, with Ingress disabled.
+- An Ark `MCPServer` resource so the server's tools are discovered. The address defaults to the in-cluster service of this release, so the chart is namespace-portable.
+
+## Quick Start
+
+### Installation
+
+**Using Ark CLI (Recommended):**
+
+The server is registered as an optional Ark service. Enable it in your Ark CLI config, then install:
+
+```bash
+ark install
+```
+
+**Using DevSpace (for development):**
+
+```bash
+cd mcps/kubernetes-mcp-server
+devspace deploy
+```
+
+## Configuration
+
+Helm chart options (`chart/values.yaml`):
+
+- `kubernetes-mcp-server.config.read_only`: read-only mode (default `true`).
+- `kubernetes-mcp-server.rbac.extraRoles`: read-only roles granted to the server.
+- `kubernetes-mcp-server.httpRoute`: Gateway API routing configuration.
+- `mcpServer.create`: register the Ark `MCPServer` (default `true`).
+- `mcpServer.address`: override the server address (defaults to the in-cluster service).
+
+## Using with Ark
+
+The chart registers an `MCPServer` named `kubernetes-mcp-server`, which auto-generates `Tool` resources. Reference them from an agent:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: cluster-inspector
+spec:
+  tools:
+    - name: kubernetes-mcp-server-resources-list
+      type: custom
+    - name: kubernetes-mcp-server-resources-get
+      type: custom
+```

--- a/marketplace.json
+++ b/marketplace.json
@@ -457,6 +457,39 @@
             }
         },
         {
+            "name": "kubernetes-mcp-server",
+            "type": "mcp",
+            "displayName": "Kubernetes MCP Server",
+            "description": "Read-only kubernetes-mcp-server registered with Ark for grounding agents on cluster resources",
+            "version": "0.1.0",
+            "author": "ARK Marketplace",
+            "homepage": "https://github.com/mckinsey/agents-at-scale-marketplace",
+            "repository": "https://github.com/mckinsey/agents-at-scale-marketplace",
+            "license": "Apache-2.0",
+            "tags": [
+                "mcp",
+                "kubernetes",
+                "read-only",
+                "cluster",
+                "grounding"
+            ],
+            "category": "mcps",
+            "icon": "https://example.com/kubernetes-mcp-icon.png",
+            "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/mcps/kubernetes-mcp-server/",
+            "support": {
+                "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
+            },
+            "ark": {
+                "chartPath": "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/kubernetes-mcp-server",
+                "namespace": "default",
+                "helmReleaseName": "kubernetes-mcp-server",
+                "installArgs": [
+                    "--create-namespace"
+                ],
+                "k8sDeploymentName": "kubernetes-mcp-server"
+            }
+        },
+        {
             "name": "cobol-modernization-bundle",
             "type": "demo",
             "displayName": "COBOL Modernization Bundle",

--- a/mcps/kubernetes-mcp-server/README.md
+++ b/mcps/kubernetes-mcp-server/README.md
@@ -5,15 +5,11 @@ Read-only [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-s
 ## Quickstart
 
 ```bash
-# Show all available recipes.
-make help
+# Deploy with Helm
+helm install kubernetes-mcp-server ./chart -n default --create-namespace
 
-# Install/uninstall - sets up your local machine or cluster.
-make install
-make uninstall
-
-# Run in development mode. May require extra tools and setup, check the README.
-make dev
+# Verify
+kubectl get mcpserver kubernetes-mcp-server
 ```
 
 **Using DevSpace (for development):**

--- a/mcps/kubernetes-mcp-server/README.md
+++ b/mcps/kubernetes-mcp-server/README.md
@@ -1,0 +1,58 @@
+# Kubernetes MCP Server
+
+Read-only [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) registered with Ark for grounding agents on cluster resources. Wraps the upstream chart and layers Ark configuration: read-only mode, namespace-scoped read-only RBAC, a `localhost-gateway` HTTPRoute, and an Ark `MCPServer` registration.
+
+## Quickstart
+
+```bash
+# Show all available recipes.
+make help
+
+# Install/uninstall - sets up your local machine or cluster.
+make install
+make uninstall
+
+# Run in development mode. May require extra tools and setup, check the README.
+make dev
+```
+
+**Using DevSpace (for development):**
+
+```bash
+cd mcps/kubernetes-mcp-server
+devspace deploy
+```
+
+## What it deploys
+
+- The upstream `kubernetes-mcp-server` chart from `oci://ghcr.io/containers/charts`, in read-only mode. Only `resources_list` / `resources_get` are exposed.
+- A namespace-scoped read-only `Role`/`RoleBinding` (`ark-reader`) granting `get`/`list`/`watch` on `ark.mckinsey.com` resources and `argoproj.io` workflows / workflow templates.
+- A `localhost-gateway` `HTTPRoute` (`kubernetes-mcp-server.127.0.0.1.nip.io`), with Ingress disabled.
+- An Ark `MCPServer` resource so the server's tools are discovered. The address defaults to the in-cluster service of this release, so the chart is namespace-portable.
+
+## Configuration
+
+Helm chart options (`chart/values.yaml`):
+
+- `kubernetes-mcp-server.config.read_only`: read-only mode (default `true`).
+- `kubernetes-mcp-server.rbac.extraRoles`: read-only roles granted to the server.
+- `kubernetes-mcp-server.httpRoute`: Gateway API routing configuration.
+- `mcpServer.create`: register the Ark `MCPServer` (default `true`).
+- `mcpServer.address`: override the server address (defaults to the in-cluster service).
+
+## Using with Ark
+
+The chart registers an `MCPServer` named `kubernetes-mcp-server`, which auto-generates `Tool` resources. Reference them from an agent:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: cluster-inspector
+spec:
+  tools:
+    - name: kubernetes-mcp-server-resources-list
+      type: custom
+    - name: kubernetes-mcp-server-resources-get
+      type: custom
+```

--- a/mcps/kubernetes-mcp-server/chart/Chart.lock
+++ b/mcps/kubernetes-mcp-server/chart/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kubernetes-mcp-server
+  repository: oci://ghcr.io/containers/charts
+  version: 0.1.0
+digest: sha256:8182004fe34ccc2b04cb7e69356f85c4f4a908a97ac8902bf94e948ed4fba60d
+generated: "2026-07-10T15:41:19.309895+02:00"

--- a/mcps/kubernetes-mcp-server/chart/Chart.yaml
+++ b/mcps/kubernetes-mcp-server/chart/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: kubernetes-mcp-server
+description: Read-only kubernetes-mcp-server with Ark MCPServer registration
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+annotations:
+  ark.mckinsey.com/service: kubernetes-mcp-server
+  ark.mckinsey.com/resources: service
+dependencies:
+  - name: kubernetes-mcp-server
+    version: 0.1.0
+    repository: oci://ghcr.io/containers/charts

--- a/mcps/kubernetes-mcp-server/chart/templates/mcpserver.yaml
+++ b/mcps/kubernetes-mcp-server/chart/templates/mcpserver.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.mcpServer.create }}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: {{ .Values.mcpServer.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  address:
+    value: {{ tpl (.Values.mcpServer.address | default (printf "http://%s.%s.svc.cluster.local:8080/mcp" .Release.Name .Release.Namespace)) . | quote }} # NOSONAR - cluster-internal service communication
+  description: {{ .Values.mcpServer.description | quote }}
+  transport: {{ .Values.mcpServer.transport }}
+  pollInterval: {{ .Values.mcpServer.pollInterval }}
+  timeout: {{ .Values.mcpServer.timeout }}
+{{- end }}

--- a/mcps/kubernetes-mcp-server/chart/values.yaml
+++ b/mcps/kubernetes-mcp-server/chart/values.yaml
@@ -2,9 +2,32 @@
 # the upstream chart from ghcr.io/containers/charts, which is a dependency of
 # our own chart. It mirrors the Ark configuration the devspace deployment uses.
 kubernetes-mcp-server:
-  # Read-only mode. The server only exposes resources_list / resources_get.
+  # Restrict the exposed tool surface to the generic resources_list /
+  # resources_get pair. Combined with the namespace-scoped RBAC below, this
+  # keeps the server's blast radius aligned with what Ark actually needs.
+  # read_only alone still discovers ~14 tools (pods_list, namespaces_list,
+  # nodes_top, ...) that hit core Kubernetes APIs the SA has no permission for.
   config:
     read_only: true
+    enabled_tools:
+      - resources_list
+      - resources_get
+    # Descriptions are injected verbatim into the LLM tool schema. Steer the
+    # model toward the correct apiVersion for Ark CRDs so users can wire the
+    # tools into an agent without extra prompt engineering.
+    tool_overrides:
+      resources_list:
+        description: |
+          List Kubernetes resources of a given kind. For Ark CRDs use
+          apiVersion "ark.mckinsey.com/v1alpha1" with kinds: Agent, Team,
+          Query, Model, MCPServer, A2AServer, A2ATask, Tool, Memory,
+          ExecutionEngine, ArkConfig. For Argo use "argoproj.io/v1alpha1"
+          with kinds Workflow, WorkflowTemplate. Pass a namespace when the
+          resource is namespaced.
+      resources_get:
+        description: |
+          Get a single Kubernetes resource by name. Same apiVersion
+          conventions as resources_list.
 
   # Expose the server through the localhost-gateway Gateway API, not Ingress.
   ingress:

--- a/mcps/kubernetes-mcp-server/chart/values.yaml
+++ b/mcps/kubernetes-mcp-server/chart/values.yaml
@@ -1,0 +1,66 @@
+# Upstream kubernetes-mcp-server chart configuration. This is layered on top of
+# the upstream chart from ghcr.io/containers/charts, which is a dependency of
+# our own chart. It mirrors the Ark configuration the devspace deployment uses.
+kubernetes-mcp-server:
+  # Read-only mode. The server only exposes resources_list / resources_get.
+  config:
+    read_only: true
+
+  # Expose the server through the localhost-gateway Gateway API, not Ingress.
+  ingress:
+    enabled: false
+
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: localhost-gateway
+        namespace: ark-system
+        sectionName: http-wildcard
+    hostnames:
+      - kubernetes-mcp-server.127.0.0.1.nip.io
+
+  # Namespace-scoped read-only access to the Ark resources the server grounds
+  # agents on, plus the Argo workflows and workflow templates in the namespace.
+  rbac:
+    create: true
+    extraRoles:
+      - name: ark-reader
+        rules:
+          - apiGroups: ["ark.mckinsey.com"]
+            resources:
+              - agents
+              - teams
+              - queries
+              - models
+              - mcpservers
+              - a2aservers
+              - a2atasks
+              - tools
+              - memories
+              - executionengines
+              - arkconfigs
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["argoproj.io"]
+            resources:
+              - workflows
+              - workflowtemplates
+            verbs: ["get", "list", "watch"]
+    extraRoleBindings:
+      - name: ark-reader
+        roleRef:
+          name: ark-reader
+
+# Ark MCPServer registration. Registers the in-cluster kubernetes-mcp-server
+# with Ark so its resources_list / resources_get Tool CRDs are discovered.
+mcpServer:
+  create: true
+  name: kubernetes-mcp-server
+  description: k8s mcp server
+  transport: http
+  # Defaults to the in-cluster service the subchart deploys. Override to point
+  # at a different address.
+  address: ""
+  pollInterval: 1m
+  timeout: 30s

--- a/mcps/kubernetes-mcp-server/devspace.yaml
+++ b/mcps/kubernetes-mcp-server/devspace.yaml
@@ -1,0 +1,15 @@
+# DevSpace configuration for kubernetes-mcp-server
+version: v2beta1
+
+pipelines:
+  deploy: |-
+    create_deployments --all
+  dev: |-
+    create_deployments --all
+
+deployments:
+  kubernetes-mcp-server:
+    namespace: default
+    helm:
+      chart:
+        path: ./chart


### PR DESCRIPTION
## Summary
- Add `mcps/kubernetes-mcp-server`, a marketplace MCP item wrapping the upstream `kubernetes-mcp-server` chart (`oci://ghcr.io/containers/charts`, `0.1.0`) and layering the Ark configuration: read-only mode, namespace-scoped read-only `Role`/`RoleBinding` on `ark.mckinsey.com` resources and `argoproj.io` workflows/workflow templates, a `localhost-gateway` `HTTPRoute` (Ingress disabled), and an Ark `MCPServer` registration so the `resources_list` / `resources_get` `Tool` CRDs are discovered. The `MCPServer` address is derived from the release, so the chart is namespace-portable.
- Register the item in `marketplace.json` as `type: mcp`.
- Wire the chart into the `validate-charts` (PR + main) and `deploy-charts` (main) matrices, and add it to release-please config/manifest so it is packaged and pushed to the OCI chart registry alongside the other charts.
- Add a docs page under `docs/content/mcps/`.

This migrates the deployment previously proposed in agents-at-scale-ark PR #2758 into the marketplace, where it belongs. A companion ark PR registers it as an optional, opt-in CLI install pointing at the marketplace registry.

Opened as a draft pending the companion ark CLI PR and review.