### PR TITLE
feat(tools): add argo-workflow-runner Ark HTTP tools

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -177,6 +177,19 @@
           "jsonpath": "$.appVersion"
         }
       ]
+    },
+    "tools/argo-workflow-runner": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm",
+      "package-name": "argo-workflow-runner",
+      "extra-files": [
+        "chart/Chart.yaml",
+        {
+          "type": "yaml",
+          "path": "chart/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
     }
   }
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -16,5 +16,6 @@
   "executors/langchain": "0.1.7",
   "executors/claude-agent-sdk": "0.1.11",
   "demos/cobol-modernization-bundle/examples/data": "1.0.1",
-  "executors/openai-responses": "0.1.7"
+  "executors/openai-responses": "0.1.7",
+  "tools/argo-workflow-runner": "0.1.0"
 }

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -73,6 +73,8 @@ jobs:
           - { name: executor-claude-agent-sdk, path: executors/claude-agent-sdk, namespace: default, run-deployment-test: false }
           # disable executor-openai-responses deployment tests for PRs to avoid hitting 5m limit
           - { name: executor-openai-responses, path: executors/openai-responses, namespace: default, run-deployment-test: false }
+          # disable argo-workflow-runner deployment tests for PRs to avoid hitting 5m limit
+          - { name: argo-workflow-runner, path: tools/argo-workflow-runner, namespace: default, run-deployment-test: false }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}
@@ -193,6 +195,7 @@ jobs:
           - { name: executor-langchain, path: executors/langchain, namespace: default }
           - { name: executor-claude-agent-sdk, path: executors/claude-agent-sdk, namespace: default }
           - { name: executor-openai-responses, path: executors/openai-responses, namespace: default }
+          - { name: argo-workflow-runner, path: tools/argo-workflow-runner, namespace: default }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -85,6 +85,8 @@ jobs:
           - { name: executor-claude-agent-sdk, path: executors/claude-agent-sdk, namespace: default, run-deployment-test: false }
           # disable executor-openai-responses deployment tests for PRs to avoid hitting 5m limit
           - { name: executor-openai-responses, path: executors/openai-responses, namespace: default, run-deployment-test: false }
+          # disable argo-workflow-runner deployment tests for PRs to avoid hitting 5m limit
+          - { name: argo-workflow-runner, path: tools/argo-workflow-runner, namespace: default, run-deployment-test: false }
     uses: ./.github/workflows/_reusable-charts-cicd.yaml
     with:
       chart-name: ${{ matrix.chart.name }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Tool providers registered as `MCPServer` CRDs. Agents reference individual tools
 | [`companies-house-mcp`](./mcps/companies-house-mcp)             | UK Companies House API for company search and beneficial ownership     | [Chart](./mcps/companies-house-mcp/chart)         |
 | [`kubernetes-mcp-server`](./mcps/kubernetes-mcp-server)         | Read-only Kubernetes access for grounding agents on cluster resources  | [Chart](./mcps/kubernetes-mcp-server/chart)       |
 
+## Tools
+
+Standalone Ark `Tool` CRDs that agents attach via `spec.tools`.
+
+| Tool                                                        | Description                                                                       | Chart                                          |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- |
+| [`argo-workflow-runner`](./tools/argo-workflow-runner)      | HTTP tools to submit existing Argo WorkflowTemplates and retry/resubmit workflows | [Chart](./tools/argo-workflow-runner/chart)    |
+
 ## Quick Start
 
 ### Install with Ark CLI (Recommended)
@@ -96,6 +104,9 @@ ark install marketplace/agents/argo-make-author
 
 # MCP Servers
 ark install marketplace/mcps/kubernetes-mcp-server
+
+# Tools
+ark install marketplace/tools/argo-workflow-runner
 ```
 
 ### Deploy with Helm
@@ -148,7 +159,7 @@ Detailed documentation for marketplace services can be found in the [`docs/`](./
 
 ## Contributing
 
-1. Choose the appropriate directory (`executors/`, `services/`, `mcps/`, `agents/`, `demos/`)
+1. Choose the appropriate directory (`executors/`, `services/`, `mcps/`, `agents/`, `demos/`, `tools/`)
 2. Each component needs: Helm chart in `chart/`, `README.md`, `devspace.yaml`
 3. Add an entry to `marketplace.json`
 4. Test locally with DevSpace or Helm

--- a/docs/content/_meta.js
+++ b/docs/content/_meta.js
@@ -6,5 +6,6 @@ export default {
   mcps: 'MCP Servers',
   agents: 'Agents',
   demos: 'Demos',
+  tools: 'Tools',
   contributors: 'Contributors',
 }

--- a/docs/content/tools/_meta.js
+++ b/docs/content/tools/_meta.js
@@ -1,0 +1,3 @@
+export default {
+  'argo-workflow-runner': 'Argo Workflow Runner'
+}

--- a/docs/content/tools/argo-workflow-runner.mdx
+++ b/docs/content/tools/argo-workflow-runner.mdx
@@ -1,0 +1,98 @@
+---
+title: Argo Workflow Runner
+description: Ark HTTP tools that run existing Argo workflows without allowing arbitrary workflow definitions
+---
+
+# Argo Workflow Runner
+
+Argo Workflow Runner is a set of three standalone Ark `Tool` resources
+(`spec.type: http`) that call the Argo Workflows API server to **run** workflows
+a model cannot define. It is the "run" counterpart to
+[Argo Make Author](../agents/argo-make-author), which only authors templates.
+
+The tools let an agent:
+
+- **submit** an existing `WorkflowTemplate` by name,
+- **retry** an existing `Workflow` in place,
+- **resubmit** an existing `Workflow` as a fresh run.
+
+There is no MCP server and no image, just `Tool` CRDs that any agent attaches
+through `spec.tools`.
+
+## Why it cannot run arbitrary workflows
+
+The security boundary is the set of endpoints the tools call, not a prompt:
+
+1. Only `submit`, `retry`, and `resubmit` are ever called. The create-Workflow
+   endpoint, which accepts a full `Workflow` manifest, is never exposed.
+2. `resourceKind` is a literal `WorkflowTemplate` baked into the submit body, so
+   a model cannot submit an arbitrary `Workflow` or `CronWorkflow` kind.
+3. The target namespace is fixed at install time, never a model argument.
+4. As an outer backstop, scope the bearer token's RBAC to `create` on
+   `workflows` and `get` / `list` on `workflowtemplates` in the target namespace.
+
+The model only supplies the name of an already-existing resource plus launch
+options, never a spec.
+
+## Tools
+
+| Tool                             | Method & endpoint                          | Inputs                      |
+| -------------------------------- | ------------------------------------------ | --------------------------- |
+| `argo-submit-workflow-template`  | `POST .../workflows/<ns>/submit`           | `name`, `parameters`        |
+| `argo-retry-workflow`            | `PUT .../workflows/<ns>/<name>/retry`      | `name`, `restartSuccessful` |
+| `argo-resubmit-workflow`         | `PUT .../workflows/<ns>/<name>/resubmit`   | `name`, `memoized`          |
+
+`parameters` is a JSON array of `key=value` strings, for example
+`["risk-level=high", "mode=sequential"]`. Use `[]` to accept the template's
+declared defaults.
+
+## Requirements
+
+- **Argo Workflows with the API server enabled.** This chart does not install
+  Argo; it is a cluster prerequisite.
+- **An authentication token** for the Argo API server.
+
+## Quick Start
+
+### Installation
+
+**Using Ark CLI (Recommended):**
+
+```bash
+ark install marketplace/tools/argo-workflow-runner
+```
+
+**Using DevSpace (for Development):**
+
+```bash
+cd tools/argo-workflow-runner
+devspace deploy
+```
+
+**Using Helm:**
+
+```bash
+cd tools/argo-workflow-runner
+helm install argo-workflow-runner ./chart -n default --set auth.token=<argo-api-token>
+```
+
+## TLS
+
+Argo's API server defaults to HTTPS with a self-signed certificate, and Ark's
+HTTP tool has no skip-verify option. Point `argoServer.baseUrl` at an endpoint
+with a trusted certificate, terminate TLS in-cluster, or run argo-server with
+`--secure=false` behind a plain `http://` URL reachable only inside the cluster.
+
+## Uninstallation
+
+**Using Ark CLI:**
+
+```bash
+ark uninstall marketplace/tools/argo-workflow-runner
+```
+
+**Using Helm:**
+
+```bash
+helm uninstall argo-workflow-runner -n default
+```

--- a/marketplace.json
+++ b/marketplace.json
@@ -710,6 +710,36 @@
                 "k8sServicePort": 8000,
                 "k8sDeploymentName": "executor-langchain"
             }
+        },
+        {
+            "name": "argo-workflow-runner",
+            "type": "tool",
+            "displayName": "Argo Workflow Runner",
+            "description": "Ark HTTP tools to submit existing Argo WorkflowTemplates and retry or resubmit existing workflows by name, without allowing arbitrary workflow definitions",
+            "version": "0.1.0",
+            "author": "ARK Marketplace",
+            "homepage": "https://github.com/mckinsey/agents-at-scale-marketplace",
+            "repository": "https://github.com/mckinsey/agents-at-scale-marketplace",
+            "license": "Apache-2.0",
+            "tags": [
+                "tool",
+                "argo",
+                "workflow",
+                "http"
+            ],
+            "category": "tools",
+            "documentation": "https://mckinsey.github.io/agents-at-scale-marketplace/tools/argo-workflow-runner/",
+            "support": {
+                "url": "https://github.com/mckinsey/agents-at-scale-marketplace/issues"
+            },
+            "ark": {
+                "chartPath": "oci://ghcr.io/mckinsey/agents-at-scale-marketplace/charts/argo-workflow-runner",
+                "namespace": "default",
+                "helmReleaseName": "argo-workflow-runner",
+                "installArgs": [
+                    "--create-namespace"
+                ]
+            }
         }
     ]
 }

--- a/tools/argo-workflow-runner/README.md
+++ b/tools/argo-workflow-runner/README.md
@@ -1,0 +1,131 @@
+# Argo Workflow Runner
+
+Ark HTTP tools that **run** Argo workflows without letting a model define one.
+Three standalone `Tool` custom resources call the Argo Workflows API server to:
+
+- **submit** an existing `WorkflowTemplate` by name,
+- **retry** an existing `Workflow` in place,
+- **resubmit** an existing `Workflow` as a fresh run.
+
+There is no MCP server and no image - just `Tool` CRDs (`spec.type: http`) that
+any agent can attach through `spec.tools`. This is the "run" counterpart to
+`agents/argo-make-author`, which only authors templates.
+
+## Why it cannot run arbitrary workflows
+
+The security boundary is the set of endpoints these tools call, not a prompt:
+
+1. Only `submit`, `retry`, and `resubmit` are ever called. The create-Workflow
+   endpoint (`POST /api/v1/workflows/{namespace}`), which accepts a full
+   `Workflow` manifest, is never exposed.
+2. `resourceKind` is a literal `WorkflowTemplate` baked into the submit body. A
+   model cannot change it, so it cannot submit an arbitrary `Workflow` or
+   `CronWorkflow` kind either.
+3. The target namespace is fixed at install time (`argoServer.namespace`), never
+   a model argument, so the tools cannot reach resources in other namespaces.
+4. As an outer backstop, scope the bearer token's RBAC in the cluster: grant the
+   argo-server service account only `create` on `workflows` and `get` / `list`
+   on `workflowtemplates` in the target namespace. RBAC lives with the Argo
+   install, not this chart.
+
+The model only supplies the name of an already-existing resource plus launch
+options - never a spec.
+
+## Prerequisites
+
+- **Argo Workflows with the API server enabled.** This chart does not install
+  Argo; it is a cluster prerequisite. The tools call `argoServer.baseUrl`.
+- **An authentication token** for the Argo API server (see below).
+
+## Tools
+
+| Tool                             | Method & endpoint                                   | Inputs                          |
+| -------------------------------- | --------------------------------------------------- | ------------------------------- |
+| `argo-submit-workflow-template`  | `POST .../workflows/<ns>/submit`                    | `name`, `parameters`            |
+| `argo-retry-workflow`            | `PUT .../workflows/<ns>/<name>/retry`               | `name`, `restartSuccessful`     |
+| `argo-resubmit-workflow`         | `PUT .../workflows/<ns>/<name>/resubmit`            | `name`, `memoized`              |
+
+### `parameters` format (submit)
+
+`parameters` is a **JSON array of `key=value` strings** for the template's
+`spec.arguments.parameters`, for example:
+
+```json
+["risk-level=high", "mode=sequential"]
+```
+
+Use `[]` (the default) to accept the template's declared defaults.
+
+## Quickstart
+
+### Using Ark CLI
+
+```bash
+ark install marketplace/tools/argo-workflow-runner
+```
+
+### Using DevSpace
+
+```bash
+cd tools/argo-workflow-runner
+devspace deploy
+```
+
+### Using Helm
+
+```bash
+# Install, letting the chart create the auth Secret from a token
+helm install argo-workflow-runner ./chart -n default \
+  --set auth.token=<argo-api-token>
+
+# Uninstall
+helm uninstall argo-workflow-runner -n default
+```
+
+If you manage the auth Secret yourself, leave `auth.token` empty and point
+`auth.secretName` / `auth.key` at your Secret. The referenced value must be the
+**complete** `Authorization` header, including the `Bearer ` prefix (Ark HTTP
+tools send the header value verbatim).
+
+## Configuration
+
+| Value                   | Default                                             | Description                                                              |
+| ----------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
+| `argoServer.baseUrl`    | `https://argo-server.argo.svc.cluster.local:2746`   | Argo API server base URL. Only submit/retry/resubmit endpoints are hit.  |
+| `argoServer.namespace`  | `""`                                                | Namespace the tools act in. Empty defaults to the release namespace.     |
+| `auth.secretName`       | `argo-workflow-runner-auth`                         | Secret holding the `Authorization` header value.                         |
+| `auth.key`              | `authorization`                                     | Key within that Secret.                                                  |
+| `auth.token`            | `""`                                                | If set, the chart creates the Secret holding `Bearer <token>`.           |
+| `tools.submitName`      | `argo-submit-workflow-template`                     | Name of the submit `Tool` resource.                                      |
+| `tools.retryName`       | `argo-retry-workflow`                               | Name of the retry `Tool` resource.                                       |
+| `tools.resubmitName`    | `argo-resubmit-workflow`                            | Name of the resubmit `Tool` resource.                                    |
+| `timeout`               | `30s`                                               | Per-request timeout applied to every tool.                              |
+
+## TLS
+
+Argo's API server defaults to HTTPS with a **self-signed** certificate, and
+Ark's HTTP tool has no skip-verify option. Choose one of:
+
+- point `argoServer.baseUrl` at an endpoint presenting a **trusted** certificate,
+- terminate TLS in-cluster in front of argo-server, or
+- run argo-server with `--secure=false` and use a plain `http://...:2746` URL
+  reachable only inside the cluster network.
+
+## Attaching to an agent
+
+Reference the tool names in an agent's `spec.tools`:
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: workflow-operator
+spec:
+  tools:
+    - type: custom
+      name: argo-submit-workflow-template
+    - type: custom
+      name: argo-retry-workflow
+    - type: custom
+      name: argo-resubmit-workflow
+```

--- a/tools/argo-workflow-runner/chart/.helmignore
+++ b/tools/argo-workflow-runner/chart/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp
+*~

--- a/tools/argo-workflow-runner/chart/Chart.yaml
+++ b/tools/argo-workflow-runner/chart/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: argo-workflow-runner
+description: >-
+  Ark HTTP tools that submit existing Argo WorkflowTemplates and retry or
+  resubmit existing workflows via the Argo Workflows API. Cannot create
+  arbitrary workflows: it only references existing resources by name.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+keywords:
+  - ark
+  - tool
+  - argo
+  - workflow
+home: https://github.com/mckinsey/agents-at-scale-marketplace
+sources:
+  - https://github.com/mckinsey/agents-at-scale-marketplace
+maintainers:
+  - name: ARK Team
+    email: ark-team@mckinsey.com
+annotations:
+  ark.mckinsey.com/marketplace-item-name: tool/argo-workflow-runner

--- a/tools/argo-workflow-runner/chart/templates/_helpers.tpl
+++ b/tools/argo-workflow-runner/chart/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "argo-workflow-runner.labels" -}}
+app.kubernetes.io/name: argo-workflow-runner
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- /*
+Target namespace for every Argo API call. Defaults to the release namespace so
+the tools can only ever run templates in their own namespace unless an operator
+explicitly overrides it.
+*/ -}}
+{{- define "argo-workflow-runner.namespace" -}}
+{{- .Values.argoServer.namespace | default .Release.Namespace -}}
+{{- end -}}

--- a/tools/argo-workflow-runner/chart/templates/secret.yaml
+++ b/tools/argo-workflow-runner/chart/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.auth.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.auth.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argo-workflow-runner.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.key }}: "Bearer {{ .Values.auth.token }}"
+{{- end }}

--- a/tools/argo-workflow-runner/chart/templates/tools/resubmit-workflow.yaml
+++ b/tools/argo-workflow-runner/chart/templates/tools/resubmit-workflow.yaml
@@ -1,0 +1,53 @@
+{{- $ns := include "argo-workflow-runner.namespace" . -}}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Tool
+metadata:
+  name: {{ .Values.tools.resubmitName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argo-workflow-runner.labels" . | nindent 4 }}
+spec:
+  type: http
+  description: >-
+    Resubmit an existing Argo Workflow in the {{ $ns }} namespace, creating a
+    fresh Workflow from the same spec. Acts only on a workflow that already
+    exists, referenced by name.
+  annotations:
+    title: "Resubmit Argo Workflow"
+    readOnlyHint: false
+    destructiveHint: false
+    idempotentHint: false
+    openWorldHint: true
+  inputSchema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: >-
+          Name of the existing Workflow to resubmit. A new Workflow is created
+          from the same spec.
+      memoized:
+        type: boolean
+        description: >-
+          If true, reuse cached (memoized) outputs from the previous run where
+          possible instead of re-executing those steps. Use false for a clean
+          rerun.
+    required:
+      - name
+      - memoized
+  http:
+    url: {{ .Values.argoServer.baseUrl }}/api/v1/workflows/{{ $ns }}/{name}/resubmit
+    method: PUT
+    timeout: {{ .Values.timeout }}
+    headers:
+      - name: Authorization
+        value:
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: {{ .Values.auth.key }}
+      - name: Content-Type
+        value:
+          value: "application/json"
+    body: |
+      {"name":"{{ "{{.input.name}}" }}","namespace":"{{ $ns }}","memoized":{{ "{{.input.memoized}}" }}}

--- a/tools/argo-workflow-runner/chart/templates/tools/retry-workflow.yaml
+++ b/tools/argo-workflow-runner/chart/templates/tools/retry-workflow.yaml
@@ -1,0 +1,51 @@
+{{- $ns := include "argo-workflow-runner.namespace" . -}}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Tool
+metadata:
+  name: {{ .Values.tools.retryName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argo-workflow-runner.labels" . | nindent 4 }}
+spec:
+  type: http
+  description: >-
+    Retry an existing, finished Argo Workflow in the {{ $ns }} namespace,
+    re-running its failed nodes in place. Acts only on a workflow that already
+    exists, referenced by name.
+  annotations:
+    title: "Retry Argo Workflow"
+    readOnlyHint: false
+    destructiveHint: false
+    idempotentHint: false
+    openWorldHint: true
+  inputSchema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the existing Workflow to retry.
+      restartSuccessful:
+        type: boolean
+        description: >-
+          If true, also restart nodes that previously succeeded; if false, only
+          the failed and errored nodes are retried. Use false unless you need a
+          full rerun.
+    required:
+      - name
+      - restartSuccessful
+  http:
+    url: {{ .Values.argoServer.baseUrl }}/api/v1/workflows/{{ $ns }}/{name}/retry
+    method: PUT
+    timeout: {{ .Values.timeout }}
+    headers:
+      - name: Authorization
+        value:
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: {{ .Values.auth.key }}
+      - name: Content-Type
+        value:
+          value: "application/json"
+    body: |
+      {"name":"{{ "{{.input.name}}" }}","namespace":"{{ $ns }}","restartSuccessful":{{ "{{.input.restartSuccessful}}" }}}

--- a/tools/argo-workflow-runner/chart/templates/tools/submit-workflow-template.yaml
+++ b/tools/argo-workflow-runner/chart/templates/tools/submit-workflow-template.yaml
@@ -1,0 +1,54 @@
+{{- $ns := include "argo-workflow-runner.namespace" . -}}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Tool
+metadata:
+  name: {{ .Values.tools.submitName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argo-workflow-runner.labels" . | nindent 4 }}
+spec:
+  type: http
+  description: >-
+    Submit an existing Argo WorkflowTemplate in the {{ $ns }} namespace,
+    creating a new Workflow from it. Only pre-existing WorkflowTemplates can be
+    run - this tool cannot define an arbitrary workflow. Pass the template name
+    and, optionally, its launch parameters.
+  annotations:
+    title: "Submit Argo WorkflowTemplate"
+    readOnlyHint: false
+    destructiveHint: false
+    idempotentHint: false
+    openWorldHint: true
+  inputSchema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: >-
+          Name of an existing WorkflowTemplate in the {{ $ns }} namespace to
+          submit.
+      parameters:
+        type: string
+        description: >-
+          JSON array of "key=value" strings for the template's
+          spec.arguments.parameters, e.g. ["risk-level=high","mode=sequential"].
+          Use [] to accept the template's declared defaults.
+        default: "[]"
+    required:
+      - name
+  http:
+    url: {{ .Values.argoServer.baseUrl }}/api/v1/workflows/{{ $ns }}/submit
+    method: POST
+    timeout: {{ .Values.timeout }}
+    headers:
+      - name: Authorization
+        value:
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: {{ .Values.auth.key }}
+      - name: Content-Type
+        value:
+          value: "application/json"
+    body: |
+      {"namespace":"{{ $ns }}","resourceKind":"WorkflowTemplate","resourceName":"{{ "{{.input.name}}" }}","submitOptions":{"parameters":{{ "{{.input.parameters}}" }}}}

--- a/tools/argo-workflow-runner/chart/values.yaml
+++ b/tools/argo-workflow-runner/chart/values.yaml
@@ -1,0 +1,34 @@
+# argo-workflow-runner tool configuration
+
+# Argo Workflows API server the tools call. The tools only ever hit the
+# submit / retry / resubmit endpoints under this base URL.
+argoServer:
+  # Base URL of the Argo API server. Argo serves HTTPS with a self-signed cert
+  # by default; see the README for the TLS options (trusted cert, in-cluster
+  # TLS termination, or running argo-server with --secure=false).
+  baseUrl: "https://argo-server.argo.svc.cluster.local:2746"
+  # Namespace the tools submit into. Empty defaults to the release namespace.
+  # This is fixed at install time and is never a model-controlled argument, so
+  # the tools cannot reach templates or workflows in other namespaces.
+  namespace: ""
+
+# Bearer-token authentication for the Argo API server. The tools send the
+# secret value verbatim as the Authorization header, so it must be the full
+# header value including the "Bearer " prefix.
+auth:
+  # Secret holding the Authorization header value.
+  secretName: "argo-workflow-runner-auth"
+  key: "authorization"
+  # If set, the chart creates the Secret above holding "Bearer <token>".
+  # Leave empty to reference a Secret you manage yourself.
+  token: ""
+
+# Names of the generated Tool resources. These are the names agents reference
+# in spec.tools (type: http).
+tools:
+  submitName: "argo-submit-workflow-template"
+  retryName: "argo-retry-workflow"
+  resubmitName: "argo-resubmit-workflow"
+
+# Per-request timeout applied to every tool.
+timeout: "30s"

--- a/tools/argo-workflow-runner/devspace.yaml
+++ b/tools/argo-workflow-runner/devspace.yaml
@@ -1,0 +1,15 @@
+# DevSpace configuration for the argo-workflow-runner tools
+version: v2beta1
+
+pipelines:
+  deploy: |-
+    create_deployments --all
+  dev: |-
+    create_deployments --all
+
+deployments:
+  argo-workflow-runner:
+    namespace: default
+    helm:
+      chart:
+        path: ./chart

--- a/tools/argo-workflow-runner/tests/tool-schema-test.py
+++ b/tools/argo-workflow-runner/tests/tool-schema-test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Renders the argo-workflow-runner chart and asserts that every Tool resource
+# is a well-formed HTTP tool: spec.type is "http", it has a non-empty
+# http.url / http.method, and - critically for the security posture - the
+# submit tool hardcodes resourceKind: WorkflowTemplate in its body so the model
+# can never submit an arbitrary workflow kind.
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CHART_DIR = (SCRIPT_DIR / ".." / "chart").resolve()
+
+ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH"}
+
+
+def render() -> str:
+    print(f"Rendering {CHART_DIR} ...")
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "argo-workflow-runner",
+            str(CHART_DIR),
+            "--set",
+            "auth.token=test-token",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def validate(rendered: str) -> int:
+    docs = [d for d in yaml.safe_load_all(rendered) if d]
+    tools = [d for d in docs if d.get("kind") == "Tool"]
+
+    if len(tools) != 3:
+        print(f"FAIL: expected 3 Tool resources, rendered {len(tools)}")
+        return 1
+
+    errors = []
+    for tool in tools:
+        name = tool.get("metadata", {}).get("name", "<unknown>")
+        spec = tool.get("spec", {})
+        if spec.get("type") != "http":
+            errors.append(f"Tool '{name}': spec.type is '{spec.get('type')}', expected 'http'")
+        http = spec.get("http", {})
+        url = http.get("url")
+        method = http.get("method")
+        if not url or not str(url).startswith(("http://", "https://")):
+            errors.append(f"Tool '{name}': http.url is missing or not an http(s) URL: {url!r}")
+        if method not in ALLOWED_METHODS:
+            errors.append(f"Tool '{name}': http.method '{method}' is not one of {sorted(ALLOWED_METHODS)}")
+
+    submit = next((t for t in tools if t["spec"].get("http", {}).get("url", "").endswith("/submit")), None)
+    if submit is None:
+        errors.append("no submit tool (url ending in /submit) was rendered")
+    else:
+        body = submit["spec"]["http"].get("body", "")
+        if '"resourceKind":"WorkflowTemplate"' not in body.replace(" ", ""):
+            errors.append("submit tool body must hardcode resourceKind: WorkflowTemplate")
+        if "resourceKind" in json.dumps(submit["spec"].get("inputSchema", {})):
+            errors.append("submit tool must not expose resourceKind as a model input")
+
+    if errors:
+        print("FAIL: tool schema validation errors:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print(f"PASS: {len(tools)} HTTP tool(s) validated; submit tool pins resourceKind to WorkflowTemplate")
+    return 0
+
+
+def main() -> int:
+    return validate(render())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a new top-level `tools/` marketplace category and its first item, **argo-workflow-runner**: three standalone Ark HTTP `Tool` CRDs (no MCP server, no image) that **run** Argo workflows without letting a model define one.

| Tool | Endpoint | Model inputs |
|---|---|---|
| `argo-submit-workflow-template` | `POST .../workflows/<ns>/submit` | `name`, `parameters` |
| `argo-retry-workflow` | `PUT .../workflows/<ns>/<name>/retry` | `name`, `restartSuccessful` |
| `argo-resubmit-workflow` | `PUT .../workflows/<ns>/<name>/resubmit` | `name`, `memoized` |

This is the "run" counterpart to `agents/argo-make-author`, which only authors templates.

## Why it cannot run arbitrary workflows

The boundary is structural, not a prompt:
1. Only `submit`/`retry`/`resubmit` are called - never the create-Workflow endpoint that accepts a manifest.
2. `resourceKind` is a hardcoded literal `WorkflowTemplate` in the submit body (not model-controllable).
3. The target namespace is baked in at install time, never a model argument.
4. Documented outer backstop: scope the argo-server SA's RBAC to `create` on `workflows` and `get`/`list` on `workflowtemplates`.

## Registration

`marketplace.json`, root `README.md`, `docs/content/_meta.js` + new `docs/content/tools/`, both CI chart matrices (validate + deploy), and release-please config/manifest.

## Testing

- `helm lint` + `helm template` verified: 3 Tools, hardcoded `resourceKind`, namespace baked into URL and body, `Authorization` via `secretKeyRef`, Ark `{{.input.x}}` placeholders Helm-escaped correctly. `--set argoServer.namespace=foo` and `--set auth.token=xyz` behave as expected; secret is gated on the token.
- `tests/tool-schema-test.py` passes.
- **Exercised end-to-end on a live cluster** (Ark + Argo v3.7.2). A `Query` targeting the tool directly (`target.type: tool`) submitted a real `hello-world` WorkflowTemplate; Argo created a Workflow via `workflowTemplateRef` (a by-name reference, not an inlined spec) and it ran to `Succeeded`.

## Known caveats (not blocking, worth a look)

- **Default `baseUrl` assumes Argo in an `argo` namespace over HTTPS.** Token-less `--auth-mode=server` installs in another namespace need `--set argoServer.baseUrl=...`. Documented in the README/docs TLS section.
- **Tool-query input must be a JSON string**, e.g. `input: '{"name":"hello-world","parameters":"[]"}'` - an object fails to unmarshal. Could add this to the README if desired.
- Argo's API server uses a self-signed cert by default and Ark's HTTP tool has no skip-verify; README documents the trusted-cert / in-cluster-TLS / `--secure=false` options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)