### PR TITLE
fix(kubernetes-mcp-server): categorize as mcp in marketplace

### DIFF
--- a/mcps/kubernetes-mcp-server/chart/Chart.yaml
+++ b/mcps/kubernetes-mcp-server/chart/Chart.yaml
@@ -7,6 +7,7 @@ appVersion: 0.1.1
 annotations:
   ark.mckinsey.com/service: kubernetes-mcp-server
   ark.mckinsey.com/resources: service
+  ark.mckinsey.com/marketplace-item-name: mcp/kubernetes-mcp-server
 dependencies:
   - name: kubernetes-mcp-server
     version: 0.1.0


### PR DESCRIPTION
## Problem

Two issues with the `kubernetes-mcp-server` in the live marketplace:

1. It does **not** appear under the **mcps** category.
2. The suggested `ark install` command has `/agent` in the path instead of `/mcps`.

## Root cause

The marketplace UI and `ark install` path derive the item's category and install path from the chart's `ark.mckinsey.com/marketplace-item-name` annotation (`<type>/<name>`). Every other marketplace chart carries it (e.g. `mcp/speech-mcp-server`, `agent/noah`), but `mcps/kubernetes-mcp-server/chart/Chart.yaml` was missing it. With the annotation absent, the item landed in the wrong category and produced an incorrect install path.

## Fix

Add the missing annotation:

```yaml
ark.mckinsey.com/marketplace-item-name: mcp/kubernetes-mcp-server
```

This places the item under the **mcps** category and yields the correct command:

```bash
ark install marketplace/mcps/kubernetes-mcp-server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)