### PR TITLE
chore(deps): bump docker base images and CI actions

### DIFF
--- a/.github/workflows/_reusable-charts-cicd.yaml
+++ b/.github/workflows/_reusable-charts-cicd.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup kind (Kubernetes in Docker)
         uses: helm/kind-action@v1
@@ -52,7 +52,7 @@ jobs:
           kubectl_version: v1.29.0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "latest"
 
@@ -114,10 +114,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "latest"
 
@@ -191,7 +191,7 @@ jobs:
         working-directory: ${{ inputs.chart-path }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Chart Artifact
         uses: actions/download-artifact@v4
@@ -224,10 +224,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "latest"
 

--- a/.github/workflows/_reusable-docker-cicd.yaml
+++ b/.github/workflows/_reusable-docker-cicd.yaml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: ${{ inputs.push-to-registry }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
@@ -86,7 +86,7 @@ jobs:
       - name: Build and push by digest
         if: ${{ inputs.push-to-registry }}
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.service-path }}
           file: ${{ inputs.service-path }}/Dockerfile
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build (validation only)
         if: ${{ !inputs.push-to-registry }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.service-path }}
           file: ${{ inputs.service-path }}/Dockerfile
@@ -169,7 +169,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |

--- a/.github/workflows/_reusable-docs-cicd.yaml
+++ b/.github/workflows/_reusable-docs-cicd.yaml
@@ -25,17 +25,17 @@ jobs:
         working-directory: ./docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             docs/.next/cache
@@ -70,10 +70,10 @@ jobs:
         working-directory: ./docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: npm
@@ -86,7 +86,7 @@ jobs:
           static_site_generator: next
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             docs/.next/cache

--- a/.github/workflows/_reusable-unit-tests.yaml
+++ b/.github/workflows/_reusable-unit-tests.yaml
@@ -22,8 +22,8 @@ jobs:
           - { name: executor-claude-agent-sdk, path: executors/claude-agent-sdk }
           - { name: ark-sandbox, path: services/ark-sandbox }
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
       - name: Run pytest
         working-directory: ${{ matrix.service.path }}
         run: uv run --with pytest pytest tests/ -q
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
       - name: Validate argo-make-author agent tool schema
         working-directory: agents/argo-make-author
         run: uv run --with pyyaml python tests/tool-schema-test.py

--- a/.github/workflows/_reusable-validate-pr-title.yaml
+++ b/.github/workflows/_reusable-validate-pr-title.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Validate PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/mcps/filesystem-mcp-server/Dockerfile
+++ b/mcps/filesystem-mcp-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 

--- a/services/ark-sandbox/Dockerfile
+++ b/services/ark-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.9-slim
+FROM python:3.14.0-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Supersedes #386 and #388, with two corrections.

## Docker base images (was #386)

| File | Before | After |
|---|---|---|
| `mcps/filesystem-mcp-server/Dockerfile` | `node:22-alpine` | `node:24-alpine` |
| `services/ark-sandbox/Dockerfile` | `python:3.12.9-slim` | `python:3.14.0-slim` |

#386 proposed `node:25-alpine`. Node 25 is a non-LTS line that reached **end-of-life on 2026-06-01** and receives no further security patches — the bump would have moved this image from a supported base to an unsupported one. Dependabot picks the highest tag, not the supported one, and the build passing says nothing about EOL.

Node 24 is the active LTS, supported until 2028-04-30. The Python bump is kept as proposed.

## GitHub Actions (was #388)

Keeps the nine actions that PR jobs actually execute:

`actions/checkout@v7` · `actions/setup-node@v7` · `actions/cache@v6` · `astral-sh/setup-uv@v7` · `azure/setup-helm@v5` · `docker/setup-buildx-action@v4` · `docker/metadata-action@v6` · `docker/build-push-action@v7` · `amannn/action-semantic-pull-request@v6`

Seven were dropped, because no pull request can exercise them — a green run here would be no evidence at all:

| Action | Why unreachable from a PR |
|---|---|
| `release-please-action`, `deploy-pages` | only run on `push:` to `main` |
| `configure-pages`, `upload-pages-artifact` | guarded by workflow inputs |
| `docker/login-action` | guarded by `push-to-registry` |
| `upload-artifact`, `download-artifact` | guarded by `release-tag` |

The artifact pair is the one to be careful with. In `_reusable-charts-cicd.yaml` the upload happens during build and the download in a later `release-tag` job, so a version skew between them breaks releases. They need to move together, in their own change, and be watched on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)