### PR TITLE
fix(deps): resolve ajv and diff advisories in filesystem-mcp-server

### DIFF
--- a/mcps/filesystem-mcp-server/package-lock.json
+++ b/mcps/filesystem-mcp-server/package-lock.json
@@ -11,14 +11,13 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1103.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "diff": "^7.0.0",
+        "diff": "^9.0.0",
         "express": "^4.22.2",
         "minimatch": "^10.2.3",
         "zod": "^3.25.76",
         "zod-to-json-schema": "3.23.5"
       },
       "devDependencies": {
-        "@types/diff": "^7.0.2",
         "@types/express": "^4.17.21",
         "@types/node": "^20.9.0",
         "tsx": "^4.1.2",
@@ -1244,13 +1243,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
@@ -1362,9 +1354,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1596,9 +1588,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/mcps/filesystem-mcp-server/package.json
+++ b/mcps/filesystem-mcp-server/package.json
@@ -19,14 +19,13 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1103.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "diff": "^7.0.0",
+    "diff": "^9.0.0",
     "express": "^4.22.2",
     "minimatch": "^10.2.3",
     "zod": "^3.25.76",
     "zod-to-json-schema": "3.23.5"
   },
   "devDependencies": {
-    "@types/diff": "^7.0.2",
     "@types/express": "^4.17.21",
     "@types/node": "^20.9.0",
     "tsx": "^4.1.2",


### PR DESCRIPTION
Part 1 of 3 splitting #392. This is the security-relevant half, separated so it can land without the breaking changes bundled alongside it.

## Changes

| Package | From | To | Advisory |
|---|---|---|---|
| `ajv` | 8.17.1 | 8.20.0 | ReDoS via `$data` option (needs ≥ 8.18.0) |
| `diff` | 7.0.0 | 9.0.0 | DoS in `parsePatch`/`applyPatch` (needs ≥ 8.0.3) |
| `@types/diff` | ^7.0.2 | *removed* | — |

`ajv` is transitive through `@modelcontextprotocol/sdk` and `ajv-formats`, both of which accept `^8`, so it is a lockfile refresh with no manifest change.

`@types/diff` is dropped rather than bumped: jsdiff ships its own type definitions since v8, and [the package is now a deprecated stub](https://www.npmjs.com/package/@types/diff). #392 proposed `@types/diff@^8.0.0`, which would have installed that stub.

## Verification

jsdiff v9 does change patch serialization — it drops trailing tabs on `---`/`+++` headers and omits headers for undefined filenames. That does not reach us: `createUnifiedDiff` passes explicit filenames and headers, and there is exactly one call site (`src/adapters/filesystem/lib.ts:212`). Output compared directly:

```
v7: "Index: file\n===...===\n--- file\toriginal\n+++ file\tmodified\n@@ -1,3 +1,3 @@\n..."
v9: "Index: file\n===...===\n--- file\toriginal\n+++ file\tmodified\n@@ -1,3 +1,3 @@\n..."
```

Byte-identical. Also confirmed `npm ci` + `tsc` compile with no `@types/diff` present, and the built ESM module produces a correct diff at runtime.

Lockfile churn is 22 lines, against 799/-884 for the same file in #392.

## Remaining from #392

- **Part 2** — #396, stacked on this branch. `express` 4→5, `typescript` 5→7, `zod` 3→4. Needed a `nodenext` tsconfig and replacing `zod-to-json-schema` with `z.toJSONSchema`. Verified: all 15 tool schemas unchanged.
- **Part 3** — #397. docs `next` 16 + `nextra` 4.6. Root-caused: `nextra-theme-docs@4.6.1` destructures `children` out of props before validating against a schema that requires it, which newer zod rejects. Fixed by pinning `zod` to 4.1.12 via `overrides`. Verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


