### PR TITLE
fix(claude-agent-sdk): suppress parent query status writes for team members

### DIFF
--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -101,13 +101,16 @@ The calling engine owns the parent Query's status, stream, and memory for the wh
 A member call writes none of them, and human-in-the-loop approval is not available to a
 member — the member's engine cannot resume an approval the caller owns.
 
-Requires an Ark version that sends the query extension `target` field. Against an older
-Ark, a member call fails with `Query extension resolution only supports agent targets, got
-'team'`.
+Requires both an Ark version that sends the query extension `target` field and an executor
+image built against an ark-sdk that reads it. An older Ark never dispatches a member to its
+engine, so the member runs on the completions loop instead. A newer Ark against an older
+ark-sdk fails the member call with `Query extension resolution only supports agent targets,
+got 'team'`.
 
 In scheduler mode each member turn provisions its own sandbox, because member calls carry
-no `contextId`. Size `scheduler.config.maxActiveSandboxes` accordingly: a 3-member
-sequential team needs 3, and a selector team needs up to two per turn.
+no `contextId`. `scheduler.config.maxActiveSandboxes` defaults to `0` (unlimited); if you
+have capped it, a 3-member sequential team needs 3 and a selector team needs up to two per
+turn.
 
 ## Deployment Modes
 

--- a/executors/claude-agent-sdk/README.md
+++ b/executors/claude-agent-sdk/README.md
@@ -76,6 +76,39 @@ spec:
     You are a helpful assistant with access to filesystem tools.
 ```
 
+## Teams
+
+Agents on this executor can be members of a `Team`. Ark dispatches each member to its
+execution engine and names the member in the query extension metadata, so a member runs
+with the team transcript so far and its own conversation scope — one session directory per
+member, not one shared across the team.
+
+```yaml
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Team
+metadata:
+  name: my-team
+spec:
+  strategy: sequential
+  members:
+    - type: agent
+      name: writer
+    - type: agent
+      name: reviewer
+```
+
+The calling engine owns the parent Query's status, stream, and memory for the whole run.
+A member call writes none of them, and human-in-the-loop approval is not available to a
+member — the member's engine cannot resume an approval the caller owns.
+
+Requires an Ark version that sends the query extension `target` field. Against an older
+Ark, a member call fails with `Query extension resolution only supports agent targets, got
+'team'`.
+
+In scheduler mode each member turn provisions its own sandbox, because member calls carry
+no `contextId`. Size `scheduler.config.maxActiveSandboxes` accordingly: a 3-member
+sequential team needs 3, and a selector team needs up to two per turn.
+
 ## Deployment Modes
 
 ### Standalone

--- a/executors/claude-agent-sdk/chart/templates/rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
+    resources: ["queries", "agents", "teams", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]

--- a/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
@@ -25,7 +25,7 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
+    resources: ["queries", "agents", "teams", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   # Namespace-wide secret access is required because Model CRD API keys reference
   # dynamically-named secrets. Cannot scope with resourceNames since secret names

--- a/executors/claude-agent-sdk/src/claude_agent_scheduler/proxy.py
+++ b/executors/claude-agent-sdk/src/claude_agent_scheduler/proxy.py
@@ -100,6 +100,23 @@ def extract_context_id(body: bytes) -> tuple[str, bytes, bool]:
         return str(uuid.uuid4()), body, True
 
 
+def _reports_query_status(query_ref) -> bool:
+    """Whether this call may write the referenced Query's phase.
+
+    A query extension `target` marks the call as one member of a team: the calling
+    engine owns the parent Query's status for the whole run, so a member must not
+    write phases to it. Team member calls carry no contextId, so every one of them
+    arrives as `is_new` and would otherwise churn the parent Query's phase.
+
+    `target` reaches QueryRef from the ark-sdk version that introduced sub-target
+    dispatch; against an older SDK the attribute is absent and every call is
+    top-level, which is what that SDK can express.
+    """
+    if query_ref is None:
+        return False
+    return getattr(query_ref, "target", None) is None
+
+
 async def _best_effort_phase(status_updater, phase: str, reason: str, message: str) -> None:
     """Report a query phase without letting the report fail the query.
 
@@ -158,17 +175,20 @@ def create_proxy_app(
             ) as route_span:
                 query_ref = _extract_query_ref_from_body(raw_body) if is_new else None
                 status_updater = QueryStatusUpdater(query_ref)
+                report_status = _reports_query_status(query_ref)
 
                 # Route to sandbox based on session type
                 try:
                     if is_new:
-                        await _best_effort_phase(
-                            status_updater, "provisioning", "ExecutorProvisioning", "Provisioning sandbox",
-                        )
+                        if report_status:
+                            await _best_effort_phase(
+                                status_updater, "provisioning", "ExecutorProvisioning", "Provisioning sandbox",
+                            )
                         info = await sandbox_manager.create_sandbox(conversation_id)
-                        await _best_effort_phase(
-                            status_updater, "running", "QueryRunning", "Query is running",
-                        )
+                        if report_status:
+                            await _best_effort_phase(
+                                status_updater, "running", "QueryRunning", "Query is running",
+                            )
                     else:
                         info = await sandbox_manager.get_sandbox(conversation_id)
                         if info is None:

--- a/executors/claude-agent-sdk/tests/test_proxy.py
+++ b/executors/claude-agent-sdk/tests/test_proxy.py
@@ -1,7 +1,9 @@
 """Tests for HTTP proxy logic."""
 
+import dataclasses
 import json
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -10,7 +12,7 @@ from ark_sdk.extensions.query import QUERY_EXTENSION_METADATA_KEY, QueryRef
 from fastapi.testclient import TestClient
 
 from claude_agent_scheduler.config import SchedulerConfig
-from claude_agent_scheduler.proxy import create_proxy_app
+from claude_agent_scheduler.proxy import _reports_query_status, create_proxy_app
 from claude_agent_scheduler.sandbox_manager import SandboxCapacityError, SandboxInfo, SandboxManager
 
 
@@ -90,20 +92,31 @@ class TestProxySandboxError:
         assert body["error"]["code"] == -32000
 
 
+def _sdk_parses_target() -> bool:
+    """Whether the installed ark-sdk parses the query extension `target` field."""
+    return any(field.name == "target" for field in dataclasses.fields(QueryRef))
+
+
 def _a2a_body_with_query_ref(
     query_name: str = "q-1",
     query_namespace: str = "test-ns",
     context_id: str | None = None,
+    target: dict | None = None,
 ) -> dict:
-    """Build an A2A JSON-RPC body that includes query extension metadata."""
+    """Build an A2A JSON-RPC body that includes query extension metadata.
+
+    Pass `target` to build a sub-target call — one member of a team, dispatched by
+    the calling engine rather than by a user.
+    """
+    ref: dict = {
+        "name": query_name,
+        "namespace": query_namespace,
+    }
+    if target is not None:
+        ref["target"] = target
     message: dict = {
         "role": "user",
-        "metadata": {
-            QUERY_EXTENSION_METADATA_KEY: {
-                "name": query_name,
-                "namespace": query_namespace,
-            },
-        },
+        "metadata": {QUERY_EXTENSION_METADATA_KEY: ref},
     }
     if context_id is not None:
         message["contextId"] = context_id
@@ -171,6 +184,81 @@ class TestProxyQueryStatus:
 
         assert response.status_code == 200
         mock_updater.update_query_phase.assert_not_awaited()
+
+    def test_sub_target_call_writes_no_parent_status(
+        self, sandbox_manager: MagicMock,
+    ) -> None:
+        """A team member call must not write the parent Query's phase."""
+        sandbox_info = SandboxInfo(
+            claim_name="claim-1",
+            sandbox_name="sandbox-1",
+            service_fqdn="sandbox-1.test-ns.svc.cluster.local",
+        )
+        sandbox_manager.create_sandbox = AsyncMock(return_value=sandbox_info)
+
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(
+            return_value=httpx.Response(200, content=b'{"ok":true}', headers={"content-type": "application/json"}),
+        )
+
+        mock_updater = AsyncMock()
+        sub_target_ref = QueryRef(name="q-1", namespace="test-ns")
+        sub_target_ref.target = SimpleNamespace(type="agent", name="member-b")
+
+        with (
+            patch("claude_agent_scheduler.proxy.QueryStatusUpdater", return_value=mock_updater),
+            patch("claude_agent_scheduler.proxy._extract_query_ref_from_body", return_value=sub_target_ref),
+        ):
+            fastapi_app = create_proxy_app(sandbox_manager=sandbox_manager, http_client=mock_http)
+            client = TestClient(fastapi_app, raise_server_exceptions=False)
+
+            body = _a2a_body_with_query_ref(target={"type": "agent", "name": "member-b"})
+            response = client.post("/", json=body)
+
+        assert response.status_code == 200
+        sandbox_manager.create_sandbox.assert_awaited_once()
+        mock_updater.update_query_phase.assert_not_awaited()
+
+    @pytest.mark.skipif(
+        not _sdk_parses_target(),
+        reason="installed ark-sdk does not parse query extension 'target'; bump the pin to enable",
+    )
+    def test_sub_target_metadata_is_honoured(
+        self, sandbox_manager: MagicMock,
+    ) -> None:
+        """The gate reads `target` off the wire, not just off a hand-built QueryRef."""
+        sandbox_info = SandboxInfo(
+            claim_name="claim-1",
+            sandbox_name="sandbox-1",
+            service_fqdn="sandbox-1.test-ns.svc.cluster.local",
+        )
+        sandbox_manager.create_sandbox = AsyncMock(return_value=sandbox_info)
+
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(
+            return_value=httpx.Response(200, content=b'{"ok":true}', headers={"content-type": "application/json"}),
+        )
+
+        mock_updater = AsyncMock()
+
+        with patch("claude_agent_scheduler.proxy.QueryStatusUpdater", return_value=mock_updater):
+            fastapi_app = create_proxy_app(sandbox_manager=sandbox_manager, http_client=mock_http)
+            client = TestClient(fastapi_app, raise_server_exceptions=False)
+
+            body = _a2a_body_with_query_ref(target={"type": "agent", "name": "member-b"})
+            response = client.post("/", json=body)
+
+        assert response.status_code == 200
+        mock_updater.update_query_phase.assert_not_awaited()
+
+    def test_reports_query_status_gate(self) -> None:
+        """The gate is the presence of a target, not the presence of a query ref."""
+        assert _reports_query_status(QueryRef(name="q-1", namespace="test-ns")) is True
+        assert _reports_query_status(None) is False
+
+        sub_target = QueryRef(name="q-1", namespace="test-ns")
+        sub_target.target = SimpleNamespace(type="agent", name="member-b")
+        assert _reports_query_status(sub_target) is False
 
     def test_status_update_failure_does_not_block(
         self, sandbox_manager: MagicMock, http_client: httpx.AsyncClient,

--- a/executors/langchain/chart/templates/rbac.yaml
+++ b/executors/langchain/chart/templates/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
+    resources: ["queries", "agents", "teams", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]

--- a/executors/openai-responses/chart/templates/rbac.yaml
+++ b/executors/openai-responses/chart/templates/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 rules:
   - apiGroups: ["ark.mckinsey.com"]
-    resources: ["queries", "agents", "models", "tools", "mcpservers", "executionengines"]
+    resources: ["queries", "agents", "teams", "models", "tools", "mcpservers", "executionengines"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]


### PR DESCRIPTION
Fixes part of #3116

## Summary
- Ark now dispatches engine-backed agents that are members of a `Team` to their
  named `ExecutionEngine`, naming the member in the query extension `target`
  field (mckinsey/agents-at-scale-ark#3116).
- The scheduler proxy writes Query status independently of ark-sdk, so the SDK's
  sub-target suppression does not reach it. Member calls carry no `contextId`, so
  every one arrives as `is_new` — a 3-member sequential team wrote
  `provisioning`/`running` to the **parent** Query six times, and a late write
  could land after the controller had already written a terminal phase.
- Proxy now reports Query phase only for top-level calls. A call whose query
  extension carries a `target` is one member of a team; the calling engine owns
  the parent Query's status for the whole run.
- Also suppresses phase reporting for requests carrying no query extension
  metadata. Those previously called a no-op updater that logged a warning per
  request; no status was ever written for them.
- The gate reads `target` defensively, so this is safe against both the currently
  pinned ark-sdk and the version that introduces sub-target dispatch.
- README documents Team membership, the no-status/no-stream/no-memory and
  no-approval contract for members, the Ark version floor, and the
  sandbox-per-member-turn capacity implication in scheduler mode.

## Pending
- ark-sdk pin bump in all three executors, once the new version publishes to
  PyPI. Until then the sub-target path is inert and one test self-skips.
- Executor images must be rebuilt and published for any of this to reach users.

## Not addressed
- Each member turn still provisions its own sandbox. A deterministic
  per-`(query, agent)` `contextId` would allow reuse, but `extract_context_id`
  reports `is_new=True` only when `contextId` is absent, so any value Ark supplies
  takes the `get_sandbox` path and 404s. Scheduler-side follow-up.