### PR TITLE
fix(deps): pin uuid under form-data2

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3962,14 +3962,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/form-data2/node_modules/uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/form-fix-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/form-fix-array/-/form-fix-array-1.0.0.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,6 +43,9 @@
     "mermaid": {
       "uuid": "^11.1.1"
     },
+    "form-data2": {
+      "uuid": "^11.1.1"
+    },
     "serve-handler": {
       "minimatch": "^3.1.3"
     },


### PR DESCRIPTION
Closes 1 Dependabot alert in `docs` (CVE-2026-41907). `uuid` is transitive, so the fix is an override rather than a dependency change.

| package | from → to | advisory | pulled by |
|---|---|---|---|
| uuid | 2.0.3 → 11.1.1 | CVE-2026-41907 | `broken-link-checker → bhttp → form-data2` |

## The alert is not what it looks like

The top-level `uuid` is already 11.1.1. npm had installed a **nested** 2.0.3 under `form-data2`, because the ranges conflicted:

```
├─┬ @theguild/remark-mermaid → mermaid → uuid@11.1.1
└─┬ broken-link-checker → bhttp → form-data2 → uuid@2.0.3   ← the alert
```

Reading `node_modules/uuid` would have led to dismissing this as already fixed. The top-level version says nothing about what the tree actually contains.

## Why this needed running, not reading

Overriding it makes `form-data2` (published 2018) jump nine majors. It calls `require("uuid").v4()`, which uuid 11 still exports from its CJS build — but that was verified by executing it, not by inspection:

- `form-data2` generates a boundary normally
- `npm run check-links` is the code path that traverses that entire chain — passes, 3417 links, 0 broken
- `npm run build` passes

The override is scoped to `form-data2` rather than applied globally, so it cannot disturb `mermaid`, which carries its own `uuid` override.

## Size

3 lines added to `package.json`, 8 removed from the lockfile — `node_modules/form-data2/node_modules/uuid` disappears. Nothing else changed, and re-running `npm install --package-lock-only` produces no further diff, so the lockfile is a genuine solver fixed point rather than a hand-merged one.