### PR TITLE
fix(deps): bump fast-uri to 3.1.6 for four SSRF and host-confusion CVEs

### DIFF
--- a/mcps/filesystem-mcp-server/package-lock.json
+++ b/mcps/filesystem-mcp-server/package-lock.json
@@ -1828,9 +1828,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Bumps `fast-uri` 3.1.5 → 3.1.6 in `mcps/filesystem-mcp-server`, closing four
  High-severity Xray violations. Transitive via `ajv`, whose `^3.0.1` range
  already permits 3.1.6, so this is a lockfile-only change with no override
  needed and no API surface to migrate.

| violation | CVE | issue |
|---|---|---|
| XRAY-1060097 | CVE-2026-75931 | host confusion via skipped IDN canonicalization |
| XRAY-1060098 | CVE-2026-75975 | SSRF via malformed IPv6 normalization |
| XRAY-1060099 | CVE-2026-75899 | SSRF via repeated hostname percent-decoding |
| XRAY-1060100 | CVE-2026-76172 | host confusion via percent-encoded scheme normalization |

These landed after `main` last passed the Xray gate, so they currently block
every open PR in the repo.
