### PR TITLE
fix: validate conversationId before using it as a session directory path

### DIFF
--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -25,7 +25,7 @@ def resolve_session_dir(conversation_id: str) -> Path:
     the A2A contextId and the a2a-context-id annotation, so the join is guarded here
     rather than at any single caller.
     """
-    if not SAFE_CONVERSATION_ID.match(conversation_id or ""):
+    if not SAFE_CONVERSATION_ID.fullmatch(conversation_id or ""):
         raise ValueError(
             f"invalid conversationId: must match {SAFE_CONVERSATION_ID.pattern}"
         )

--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -105,33 +105,45 @@ class ClaudeAgentExecutor(BaseExecutor):
         return sdk_servers, allowed_tools
 
     async def execute_agent(self, request) -> List[Message]:
-        """Execute agent using ClaudeSDKClient and return response messages."""
-        conversation_id = request.conversationId
+        """Execute agent using ClaudeSDKClient and return response messages.
+
+        An absent conversationId means an unthreaded query, which is the default:
+        Query.spec.conversationId is optional and the SDK passes "" when it is
+        unset. Such a query runs in the sessions root with no session to resume,
+        rather than being rejected as an invalid path segment. Resume is skipped
+        because sessions are keyed by working directory, so resuming here would
+        hand one unthreaded query the transcript of an unrelated one.
+        """
+        conversation_id = request.conversationId or None
         user_input = request.userInput.content
 
         if not user_input:
             return [Message(role="assistant", content="Error: user input is required", name=request.agent.name)]
 
-        try:
-            session_dir = resolve_session_dir(conversation_id)
-        except ValueError as e:
-            logger.warning(f"Rejected conversationId for agent {request.agent.name}: {e}")
-            return [Message(role="assistant", content=f"Error: {e}", name=request.agent.name)]
+        if conversation_id:
+            try:
+                session_dir = resolve_session_dir(conversation_id)
+            except ValueError as e:
+                logger.warning(f"Rejected conversationId for agent {request.agent.name}: {e}")
+                return [Message(role="assistant", content=f"Error: {e}", name=request.agent.name)]
+        else:
+            session_dir = SESSIONS_DIR.resolve()
 
         model_name, api_key, base_url = self._resolve_model_config(request)
 
-        logger.info(f"Executing Claude Agent SDK query for agent {request.agent.name} (model: {model_name}, conversation: {conversation_id})")
+        logger.info(f"Executing Claude Agent SDK query for agent {request.agent.name} (model: {model_name}, conversation: {conversation_id or 'unthreaded'})")
 
         session_dir.mkdir(parents=True, exist_ok=True)
 
         # Find existing session to resume
         previous_session_id = None
-        try:
-            sessions = list_sessions(directory=str(session_dir), limit=1)
-            if sessions:
-                previous_session_id = sessions[0].session_id
-        except Exception:
-            logger.debug("Could not list sessions for %s", session_dir, exc_info=True)
+        if conversation_id:
+            try:
+                sessions = list_sessions(directory=str(session_dir), limit=1)
+                if sessions:
+                    previous_session_id = sessions[0].session_id
+            except Exception:
+                logger.debug("Could not list sessions for %s", session_dir, exc_info=True)
 
         mcp_kwargs: Dict = {}
         mcp_servers = getattr(request, "mcpServers", None) or []
@@ -165,7 +177,7 @@ class ClaudeAgentExecutor(BaseExecutor):
             **prompt_kwargs,
             **resume_kwargs,
         )
-        logger.info(f"{'Resuming session ' + previous_session_id if previous_session_id else 'Starting new session'} for conversation {conversation_id}")
+        logger.info(f"{'Resuming session ' + previous_session_id if previous_session_id else 'Starting new session'} for conversation {conversation_id or 'unthreaded'}")
 
         try:
             result_text = ""

--- a/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
+++ b/executors/claude-agent-sdk/src/claude_agent_executor/executor.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -13,6 +14,29 @@ from claude_agent_sdk.types import AssistantMessage, TextBlock, ToolUseBlock
 logger = logging.getLogger(__name__)
 
 SESSIONS_DIR = Path(os.getenv("SESSIONS_DIR", "/data/sessions"))
+
+SAFE_CONVERSATION_ID = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$")
+
+
+def resolve_session_dir(conversation_id: str) -> Path:
+    """Map a conversationId to its session directory, rejecting path traversal.
+
+    conversationId reaches the executor unvalidated from Query.spec.conversationId,
+    the A2A contextId and the a2a-context-id annotation, so the join is guarded here
+    rather than at any single caller.
+    """
+    if not SAFE_CONVERSATION_ID.match(conversation_id or ""):
+        raise ValueError(
+            f"invalid conversationId: must match {SAFE_CONVERSATION_ID.pattern}"
+        )
+
+    root = SESSIONS_DIR.resolve()
+    resolved = (root / conversation_id).resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError("conversationId resolves outside the sessions directory")
+
+    return resolved
+
 
 # Executor-specific instrumentation — only the Claude Agent SDK instrumentor
 if is_otel_enabled():
@@ -88,11 +112,16 @@ class ClaudeAgentExecutor(BaseExecutor):
         if not user_input:
             return [Message(role="assistant", content="Error: user input is required", name=request.agent.name)]
 
+        try:
+            session_dir = resolve_session_dir(conversation_id)
+        except ValueError as e:
+            logger.warning(f"Rejected conversationId for agent {request.agent.name}: {e}")
+            return [Message(role="assistant", content=f"Error: {e}", name=request.agent.name)]
+
         model_name, api_key, base_url = self._resolve_model_config(request)
 
         logger.info(f"Executing Claude Agent SDK query for agent {request.agent.name} (model: {model_name}, conversation: {conversation_id})")
 
-        session_dir = SESSIONS_DIR / conversation_id
         session_dir.mkdir(parents=True, exist_ok=True)
 
         # Find existing session to resume

--- a/executors/claude-agent-sdk/tests/test_conversation_id.py
+++ b/executors/claude-agent-sdk/tests/test_conversation_id.py
@@ -93,6 +93,79 @@ class TestResolveSessionDir:
         assert not outside.exists()
 
 
+class TestUnthreadedQueriesStillRun:
+    """An unset conversationId is the default, not an invalid path segment.
+
+    Query.spec.conversationId is optional and the SDK sends "" when it is unset,
+    so validating it unconditionally turned every ordinary one-shot query into
+    "Error: invalid conversationId".
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversation_id", ["", None])
+    async def test_unthreaded_runs_in_sessions_root(self, conversation_id, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, options=None):
+                captured["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                return
+                yield
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            messages = await executor.execute_agent(_request(conversation_id))
+
+        assert not any(m.content.startswith("Error:") for m in messages)
+        assert captured["options"].cwd == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversation_id", ["", None])
+    async def test_unthreaded_never_resumes_another_session(self, conversation_id, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, options=None):
+                captured["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                return
+                yield
+
+        stray = MagicMock()
+        stray.session_id = "someone-elses-session"
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient), \
+             patch("claude_agent_executor.executor.list_sessions", return_value=[stray]) as listed:
+            await executor.execute_agent(_request(conversation_id))
+
+        listed.assert_not_called()
+        assert getattr(captured["options"], "resume", None) is None
+
+
 class TestExecuteAgentRejection:
     """The escalation being closed: a rejected id must never reach ClaudeAgentOptions."""
 

--- a/executors/claude-agent-sdk/tests/test_conversation_id.py
+++ b/executors/claude-agent-sdk/tests/test_conversation_id.py
@@ -1,0 +1,158 @@
+"""Tests for conversationId validation guarding the session directory join."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from claude_agent_executor.executor import (
+    SAFE_CONVERSATION_ID,
+    ClaudeAgentExecutor,
+    resolve_session_dir,
+)
+
+
+REJECTED = [
+    "/",
+    "..",
+    "../../../tmp/pwned",
+    "/etc/passwd",
+    ".",
+    "",
+    "a/b",
+    "a b",
+    "a.b",
+    ".hidden",
+    "-leading-dash",
+    "_leading-underscore",
+    "a" * 129,
+]
+
+ACCEPTED = [
+    "a",
+    "normal-id",
+    "abc_123-XYZ",
+    "hitl-demo-conv-001",
+    "chat-alice-001",
+    "conv-123",
+    "550e8400-e29b-41d4-a716-446655440000",
+    "a" * 128,
+]
+
+
+def _model_config():
+    model = MagicMock()
+    model.name = "claude-sonnet-4-20250514"
+    model.config = {"anthropic": {"apiKey": "sk-test-key"}}
+    return model
+
+
+def _request(conversation_id):
+    request = MagicMock()
+    request.conversationId = conversation_id
+    request.userInput.content = "hello"
+    request.agent.name = "test-agent"
+    request.agent.prompt = ""
+    request.agent.model = _model_config()
+    request.mcpServers = []
+    return request
+
+
+class TestResolveSessionDir:
+    @pytest.mark.parametrize("conversation_id", REJECTED)
+    def test_rejects_unsafe(self, conversation_id, tmp_path):
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path):
+            with pytest.raises(ValueError):
+                resolve_session_dir(conversation_id)
+
+    @pytest.mark.parametrize("conversation_id", ACCEPTED)
+    def test_accepts_safe(self, conversation_id, tmp_path):
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path):
+            resolved = resolve_session_dir(conversation_id)
+
+        assert resolved.is_relative_to(tmp_path.resolve())
+        assert resolved.name == conversation_id
+
+    def test_rejects_none(self, tmp_path):
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path):
+            with pytest.raises(ValueError):
+                resolve_session_dir(None)
+
+    def test_no_directory_created_outside_root(self, tmp_path):
+        root = tmp_path / "sessions"
+        root.mkdir()
+        outside = tmp_path / "outside"
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", root):
+            with pytest.raises(ValueError):
+                resolve_session_dir("../outside")
+
+        assert not outside.exists()
+
+
+class TestExecuteAgentRejection:
+    """The escalation being closed: a rejected id must never reach ClaudeAgentOptions."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversation_id", ["/", "..", "../../../tmp/pwned", "/etc/passwd"])
+    async def test_rejected_id_never_builds_options(self, conversation_id, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+        constructed = []
+
+        class FakeClient:
+            def __init__(self, options=None):
+                constructed.append(options)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                return
+                yield
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            messages = await executor.execute_agent(_request(conversation_id))
+
+        assert constructed == []
+        assert len(messages) == 1
+        assert messages[0].content.startswith("Error: invalid conversationId")
+
+    @pytest.mark.asyncio
+    async def test_accepted_id_confines_cwd_to_sessions_dir(self, tmp_path):
+        executor = ClaudeAgentExecutor.__new__(ClaudeAgentExecutor)
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, options=None):
+                captured["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def query(self, prompt):
+                pass
+
+            async def receive_response(self):
+                return
+                yield
+
+        with patch("claude_agent_executor.executor.SESSIONS_DIR", tmp_path), \
+             patch("claude_agent_executor.executor.ClaudeSDKClient", FakeClient):
+            await executor.execute_agent(_request("safe-conv-001"))
+
+        cwd = captured["options"].cwd
+        assert cwd != "/"
+        assert cwd == str(tmp_path.resolve() / "safe-conv-001")
+
+
+class TestPattern:
+    def test_pattern_matches_crd_marker(self):
+        assert SAFE_CONVERSATION_ID.pattern == r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$"

--- a/executors/claude-agent-sdk/tests/test_conversation_id.py
+++ b/executors/claude-agent-sdk/tests/test_conversation_id.py
@@ -24,6 +24,11 @@ REJECTED = [
     "-leading-dash",
     "_leading-underscore",
     "a" * 129,
+    "safe-id\n",
+    "a" * 128 + "\n",
+    "\n",
+    "safe-id\n../../etc",
+    "safe-id\r\n",
 ]
 
 ACCEPTED = [

--- a/executors/openai-responses/src/openai_responses_executor/chat_api.py
+++ b/executors/openai-responses/src/openai_responses_executor/chat_api.py
@@ -165,6 +165,11 @@ async def chat(request: Request) -> StreamingResponse | JSONResponse:
         return JSONResponse({"error": "conversationId is required"}, status_code=400)
 
     try:
+        sessions.validate_conversation_id(conversation_id)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    try:
         ctx = await _resolve_context(request)
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)
@@ -192,6 +197,10 @@ async def reset_chat(request: Request) -> JSONResponse:
     conversation_id = (body.get("conversationId") or "").strip()
     if not conversation_id:
         return JSONResponse({"error": "conversationId is required"}, status_code=400)
+    try:
+        sessions.validate_conversation_id(conversation_id)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
     await sessions.clear_conversation(conversation_id)
     return JSONResponse({"ok": True, "conversationId": conversation_id})
 

--- a/executors/openai-responses/src/openai_responses_executor/sessions.py
+++ b/executors/openai-responses/src/openai_responses_executor/sessions.py
@@ -20,15 +20,42 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from pathlib import Path
 
 from .config import config
 
 logger = logging.getLogger(__name__)
 
+SAFE_CONVERSATION_ID = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$")
+
+
+def validate_conversation_id(conversation_id: str) -> None:
+    """Raise ValueError if conversation_id is not safe as a path segment.
+
+    Exposed so HTTP handlers can reject early and return 400 rather than failing
+    once a streaming response is already in flight.
+    """
+    if not SAFE_CONVERSATION_ID.match(conversation_id or ""):
+        raise ValueError(
+            f"invalid conversationId: must match {SAFE_CONVERSATION_ID.pattern}"
+        )
+
 
 def _conv_dir(conversation_id: str) -> Path:
-    return config.sessions_dir / conversation_id
+    """Resolve a conversation's directory, rejecting path traversal.
+
+    conversation_id arrives unvalidated from both the A2A contextId and the
+    /chat request body, so every read, write and unlink is guarded here.
+    """
+    validate_conversation_id(conversation_id)
+
+    root = config.sessions_dir.resolve()
+    resolved = (root / conversation_id).resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError("conversationId resolves outside the sessions directory")
+
+    return resolved
 
 
 def _read_response_id(conversation_id: str) -> str | None:

--- a/executors/openai-responses/src/openai_responses_executor/sessions.py
+++ b/executors/openai-responses/src/openai_responses_executor/sessions.py
@@ -36,7 +36,7 @@ def validate_conversation_id(conversation_id: str) -> None:
     Exposed so HTTP handlers can reject early and return 400 rather than failing
     once a streaming response is already in flight.
     """
-    if not SAFE_CONVERSATION_ID.match(conversation_id or ""):
+    if not SAFE_CONVERSATION_ID.fullmatch(conversation_id or ""):
         raise ValueError(
             f"invalid conversationId: must match {SAFE_CONVERSATION_ID.pattern}"
         )

--- a/executors/openai-responses/tests/test_conversation_id.py
+++ b/executors/openai-responses/tests/test_conversation_id.py
@@ -1,0 +1,106 @@
+"""Tests for conversationId validation guarding the session directory join."""
+
+import pytest
+from unittest.mock import patch
+
+from openai_responses_executor import sessions
+
+
+REJECTED = [
+    "/",
+    "..",
+    "../../../tmp/pwned",
+    "/etc/passwd",
+    ".",
+    "",
+    "a/b",
+    "a b",
+    "a.b",
+    ".hidden",
+    "-leading-dash",
+    "a" * 129,
+]
+
+ACCEPTED = [
+    "a",
+    "normal-id",
+    "abc_123-XYZ",
+    "hitl-demo-conv-001",
+    "conv-123",
+    "550e8400-e29b-41d4-a716-446655440000",
+    "a" * 128,
+]
+
+
+class TestValidateConversationId:
+    @pytest.mark.parametrize("conversation_id", REJECTED)
+    def test_rejects_unsafe(self, conversation_id):
+        with pytest.raises(ValueError):
+            sessions.validate_conversation_id(conversation_id)
+
+    @pytest.mark.parametrize("conversation_id", ACCEPTED)
+    def test_accepts_safe(self, conversation_id):
+        sessions.validate_conversation_id(conversation_id)
+
+    def test_rejects_none(self):
+        with pytest.raises(ValueError):
+            sessions.validate_conversation_id(None)
+
+
+class TestConvDir:
+    @pytest.mark.parametrize("conversation_id", REJECTED)
+    def test_rejects_unsafe(self, conversation_id, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            with pytest.raises(ValueError):
+                sessions._conv_dir(conversation_id)
+
+    def test_confines_to_sessions_dir(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            resolved = sessions._conv_dir("safe-conv-001")
+
+        assert resolved.is_relative_to(tmp_path.resolve())
+        assert resolved.name == "safe-conv-001"
+
+
+class TestWritersRejectTraversal:
+    """Every write and unlink path routes through _conv_dir, so all are guarded."""
+
+    @pytest.mark.asyncio
+    async def test_save_response_id_rejects(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            with pytest.raises(ValueError):
+                await sessions.save_response_id("../pwned", "resp_123")
+
+        assert not (tmp_path.parent / "pwned").exists()
+
+    @pytest.mark.asyncio
+    async def test_mark_file_ids_sent_rejects(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            with pytest.raises(ValueError):
+                await sessions.mark_file_ids_sent("../pwned", {"file-1"})
+
+        assert not (tmp_path.parent / "pwned").exists()
+
+    @pytest.mark.asyncio
+    async def test_clear_conversation_rejects(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            with pytest.raises(ValueError):
+                await sessions.clear_conversation("../pwned")
+
+    @pytest.mark.asyncio
+    async def test_get_previous_response_id_rejects(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            with pytest.raises(ValueError):
+                await sessions.get_previous_response_id("/etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_round_trip_with_safe_id(self, tmp_path):
+        with patch.object(sessions.config, "sessions_dir", tmp_path):
+            await sessions.save_response_id("safe-conv-001", "resp_123")
+            assert await sessions.get_previous_response_id("safe-conv-001") == "resp_123"
+
+            await sessions.mark_file_ids_sent("safe-conv-001", {"file-1"})
+            assert await sessions.get_sent_file_ids("safe-conv-001") == {"file-1"}
+
+            await sessions.clear_conversation("safe-conv-001")
+            assert await sessions.get_previous_response_id("safe-conv-001") is None

--- a/executors/openai-responses/tests/test_conversation_id.py
+++ b/executors/openai-responses/tests/test_conversation_id.py
@@ -19,6 +19,11 @@ REJECTED = [
     ".hidden",
     "-leading-dash",
     "a" * 129,
+    "safe-id\n",
+    "a" * 128 + "\n",
+    "\n",
+    "safe-id\n../../etc",
+    "safe-id\r\n",
 ]
 
 ACCEPTED = [


### PR DESCRIPTION
## Summary
- `conversationId` was used unvalidated as a filesystem path segment, so a value like `/` or `../../../tmp` resolved outside the sessions directory
- Added a shared character rule (`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$`), applied with `fullmatch` so a trailing newline cannot slip past `$`, plus a `resolve()`/`is_relative_to()` backstop in both affected executors
- `claude-agent-sdk`: a supplied conversationId is validated before the session directory is built, returning an `Error:` message the same way the empty-input case does. An absent one is the default and means an unthreaded query — it runs in the sessions root with no session to resume, since sessions are keyed by working directory and resuming there would hand one unthreaded query the transcript of an unrelated one
- `openai-responses`: the guard sits in `_conv_dir`, the single entry point for all reads, writes and deletes; `/chat` and `/chat/reset` validate up front and return 400 rather than failing mid-stream
- 86 tests covering rejected and accepted values, trailing-newline inputs, unthreaded queries, and asserting a rejected id never reaches the agent options
