### PR TITLE
feat(kubernetes-mcp-server): hold MCP address in an Ark Configuration

### DIFF
--- a/docs/content/mcps/kubernetes-mcp-server.mdx
+++ b/docs/content/mcps/kubernetes-mcp-server.mdx
@@ -19,7 +19,8 @@ In read-only mode the server exposes resource inspection tools (prefixed with `k
 - The upstream `kubernetes-mcp-server` chart from `oci://ghcr.io/containers/charts`, in read-only mode.
 - A namespace-scoped read-only `Role`/`RoleBinding` (`ark-reader`) granting `get`/`list`/`watch` on `ark.mckinsey.com` resources and `argoproj.io` workflows / workflow templates.
 - A `localhost-gateway` `HTTPRoute`, with Ingress disabled.
-- An Ark `MCPServer` resource so the server's tools are discovered. The address defaults to the in-cluster service of this release, so the chart is namespace-portable.
+- An Ark `MCPServer` resource so the server's tools are discovered. It reads the address from the ConfigMap below rather than holding it inline.
+- An Ark Configuration `ConfigMap` (`<release>-address`) holding the server address, defaulting to the in-cluster service of this release, so the chart is namespace-portable.
 
 ## Quick Start
 
@@ -40,6 +41,14 @@ cd mcps/kubernetes-mcp-server
 devspace deploy
 ```
 
+## Changing the address
+
+The address lives in the `<release>-address` ConfigMap, labelled `ark.mckinsey.com/resource-type: configuration`, so it appears on the Ark dashboard's Configurations page and can be edited there without cluster access. The `MCPServer` controller picks the change up and rediscovers tools within one `pollInterval` (default 1m).
+
+The chart preserves an edit made this way: `helm upgrade` reads the value already in the cluster instead of overwriting it with the default. Precedence is `--set mcpServer.address` > the value in the cluster > the in-cluster default.
+
+Because the preservation uses Helm's `lookup`, which cannot query a cluster during `helm template` or `--dry-run`, rendering the chart offline always shows the default address.
+
 ## Configuration
 
 Helm chart options (`chart/values.yaml`):
@@ -47,8 +56,9 @@ Helm chart options (`chart/values.yaml`):
 - `kubernetes-mcp-server.config.read_only`: read-only mode (default `true`).
 - `kubernetes-mcp-server.rbac.extraRoles`: read-only roles granted to the server.
 - `kubernetes-mcp-server.httpRoute`: Gateway API routing configuration.
-- `mcpServer.create`: register the Ark `MCPServer` (default `true`).
-- `mcpServer.address`: override the server address (defaults to the in-cluster service).
+- `mcpServer.create`: register the Ark `MCPServer` and its address ConfigMap (default `true`).
+- `mcpServer.address`: pin the server address, overriding any dashboard edit.
+- `mcpServer.configuration.description`: description shown on the Configurations page.
 
 ## Using with Ark
 

--- a/mcps/kubernetes-mcp-server/README.md
+++ b/mcps/kubernetes-mcp-server/README.md
@@ -24,7 +24,25 @@ devspace deploy
 - The upstream `kubernetes-mcp-server` chart from `oci://ghcr.io/containers/charts`, in read-only mode. Only `resources_list` / `resources_get` are exposed.
 - A namespace-scoped read-only `Role`/`RoleBinding` (`ark-reader`) granting `get`/`list`/`watch` on `ark.mckinsey.com` resources and `argoproj.io` workflows / workflow templates.
 - A `localhost-gateway` `HTTPRoute` (`kubernetes-mcp-server.127.0.0.1.nip.io`), with Ingress disabled.
-- An Ark `MCPServer` resource so the server's tools are discovered. The address defaults to the in-cluster service of this release, so the chart is namespace-portable.
+- An Ark `MCPServer` resource so the server's tools are discovered. It reads the address from the ConfigMap below rather than holding it inline.
+- An Ark Configuration `ConfigMap` (`<release>-address`) holding the server address, defaulting to the in-cluster service of this release, so the chart is namespace-portable.
+
+## Changing the address
+
+The address lives in the `<release>-address` ConfigMap, labelled
+`ark.mckinsey.com/resource-type: configuration`, so it appears on the Ark
+dashboard's Configurations page and can be edited there without cluster access.
+The `MCPServer` controller picks the change up and rediscovers tools within one
+`pollInterval` (default 1m).
+
+The chart preserves an edit made this way: `helm upgrade` reads the value
+already in the cluster instead of overwriting it with the default. Precedence
+is `--set mcpServer.address` > the value in the cluster > the in-cluster
+default.
+
+Because the preservation uses Helm's `lookup`, which cannot query a cluster
+during `helm template` or `--dry-run`, rendering the chart offline always shows
+the default address.
 
 ## Configuration
 
@@ -33,8 +51,9 @@ Helm chart options (`chart/values.yaml`):
 - `kubernetes-mcp-server.config.read_only`: read-only mode (default `true`).
 - `kubernetes-mcp-server.rbac.extraRoles`: read-only roles granted to the server.
 - `kubernetes-mcp-server.httpRoute`: Gateway API routing configuration.
-- `mcpServer.create`: register the Ark `MCPServer` (default `true`).
-- `mcpServer.address`: override the server address (defaults to the in-cluster service).
+- `mcpServer.create`: register the Ark `MCPServer` and its address ConfigMap (default `true`).
+- `mcpServer.address`: pin the server address, overriding any dashboard edit.
+- `mcpServer.configuration.description`: description shown on the Configurations page.
 
 ## Using with Ark
 

--- a/mcps/kubernetes-mcp-server/chart/templates/_helpers.tpl
+++ b/mcps/kubernetes-mcp-server/chart/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Name of the Ark Configuration ConfigMap holding the server address. Used by
+both configmap.yaml and mcpserver.yaml, so it is defined once.
+*/}}
+{{- define "kubernetes-mcp-server.addressConfigMapName" -}}
+{{- printf "%s-address" .Release.Name -}}
+{{- end -}}
+
+{{/*
+In-cluster address of the Service the upstream subchart deploys.
+*/}}
+{{- define "kubernetes-mcp-server.defaultAddress" -}}
+{{- printf "http://%s.%s.svc.cluster.local:8080/mcp" .Release.Name .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Resolved address: explicit override, else the value already in the cluster,
+else the in-cluster default. The middle term is what keeps a `helm upgrade`
+from silently reverting an edit made through the Ark dashboard.
+
+`lookup` cannot query a cluster during `helm template` or `--dry-run`, so
+offline renders always show the default.
+*/}}
+{{- define "kubernetes-mcp-server.address" -}}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace (include "kubernetes-mcp-server.addressConfigMapName" .) -}}
+{{- $current := "" -}}
+{{- if and $existing $existing.data -}}
+{{-   $current = index $existing.data "value" | default "" -}}
+{{- end -}}
+{{- $resolved := .Values.mcpServer.address | default $current | default (include "kubernetes-mcp-server.defaultAddress" .) -}}
+{{- tpl $resolved . -}}
+{{- end -}}

--- a/mcps/kubernetes-mcp-server/chart/templates/configmap.yaml
+++ b/mcps/kubernetes-mcp-server/chart/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.mcpServer.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubernetes-mcp-server.addressConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # Required, and required at creation: ark-api's admission policy rejects
+    # writes to ConfigMaps without it, and rejects adding it after the fact.
+    ark.mckinsey.com/resource-type: configuration
+  annotations:
+    ark.mckinsey.com/description: {{ .Values.mcpServer.configuration.description | quote }}
+data:
+  # Ark Configurations always key on `value`.
+  value: {{ include "kubernetes-mcp-server.address" . | quote }} # NOSONAR - cluster-internal service communication
+{{- end }}

--- a/mcps/kubernetes-mcp-server/chart/templates/mcpserver.yaml
+++ b/mcps/kubernetes-mcp-server/chart/templates/mcpserver.yaml
@@ -5,8 +5,13 @@ metadata:
   name: {{ .Values.mcpServer.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  # Held in an Ark Configuration ConfigMap rather than inline so it can be
+  # edited from the dashboard.
   address:
-    value: {{ tpl (.Values.mcpServer.address | default (printf "http://%s.%s.svc.cluster.local:8080/mcp" .Release.Name .Release.Namespace)) . | quote }} # NOSONAR - cluster-internal service communication
+    valueFrom:
+      configMapKeyRef:
+        name: {{ include "kubernetes-mcp-server.addressConfigMapName" . }}
+        key: value
   description: {{ .Values.mcpServer.description | quote }}
   transport: {{ .Values.mcpServer.transport }}
   pollInterval: {{ .Values.mcpServer.pollInterval }}

--- a/mcps/kubernetes-mcp-server/chart/values.yaml
+++ b/mcps/kubernetes-mcp-server/chart/values.yaml
@@ -82,8 +82,13 @@ mcpServer:
   name: kubernetes-mcp-server
   description: k8s mcp server
   transport: http
-  # Defaults to the in-cluster service the subchart deploys. Override to point
-  # at a different address.
+  # Pins the address, overriding any dashboard edit. Leave empty to keep the
+  # value already in the cluster, falling back to the in-cluster service.
   address: ""
   pollInterval: 1m
   timeout: 30s
+
+  # The address lives in the `<release>-address` ConfigMap, editable from the
+  # dashboard's Configurations page.
+  configuration:
+    description: Address the Ark controller uses to reach the Kubernetes MCP server.


### PR DESCRIPTION
## Summary

Moves the `kubernetes-mcp-server` address out of the `MCPServer` CRD and into a ConfigMap labelled as an Ark Configuration, so it can be changed from the dashboard instead of requiring cluster access and a `helm upgrade`.

```yaml
# before
address:
  value: "http://kubernetes-mcp-server.default.svc.cluster.local:8080/mcp"

# after
address:
  valueFrom:
    configMapKeyRef: {name: kubernetes-mcp-server-address, key: value}
```

### Design notes

Edits survive helm upgrade. Helm reconciles the default would wipe a dashboard edit silently. The template uses lookup to keep the value already in the cluster. Precedence: --set mcpServer.address > in-cluster value > default. Cost: lookup can't query a cluster during helm template/--dry-run, so offline renders always show the default.

The label is applied at creation. ark-api's admission policy rejects writes to ConfigMaps without it, and rejects adding it later — so a ConfigMap created without it can never become dashboard-editable.

Only this chart. The other six MCPs use serviceRef, which derives the address from the live Service. There's no lite

### Testing

CI runs lint/template/install but not upgrade, which is the path this depends on. Verified manually against a live cluster:

```bash
cd mcps/kubernetes-mcp-server
helm dependency update chart
helm install kubernetes-mcp-server ./chart -n default
```

1. Dashboard → Configurations → kubernetes-mcp-server-address is listed.
2. Edit it to an invalid address and save. Save the label; within one pollInterval the MCPServed.
3. Restore it → back to ToolsDiscovered with 2 tools.
4. Edit again, then helm upgrade with no overrides — the edit must survive.
5. helm upgrade --set mcpServer.address=... —
6. helm uninstall kubernetes-mcp-server -n default

All green, plus: mcpServer.create=false leavesion policy denies both an unlabelled write and a ld with --as=system:serviceaccount:default:ark-api-sa).

### Not in this change

The other six charts (nothing to move) · Deployment env vars (a ConfigMap change
doesn't restart pods, so it'd be a silent no-o ·
marketplace.json declarations (consumed by ark-api, inert here).
