### PR TITLE
fix(docs): pin zod to 4.1.12 to prevent nextra-theme-docs validation error

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1953,15 +1953,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@zod/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-bVfPiV2kDUkAJ4ArvV4MHcPZA8y3xOX6/SjzSy2kX2ACopbaaAP4wk6hd/byRmfi9MLNai+4SFJMmcATdOyclg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -9331,13 +9322,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.0-beta.20250424T163858",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.0-beta.20250424T163858.tgz",
-      "integrity": "sha512-fKhW+lEJnfUGo0fvQjmam39zUytARR2UdCEh7/OXJSBbKScIhD343K74nW+UUHu/r6dkzN6Uc/GqwogFjzpCXg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
-      "dependencies": {
-        "@zod/core": "0.9.0"
-      },
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -55,7 +55,8 @@
     "glob": {
       ".": "^10.5.0",
       "minimatch": "^9.0.7"
-    }
+    },
+    "zod": "4.1.12"
   },
   "optionalDependencies": {
     "@napi-rs/simple-git-linux-arm64-gnu": "^0.1.19",


### PR DESCRIPTION
Pins zod to 4.1.12 via overrides in docs/package.json to prevent the nextra-theme-docs 4.6.1 validation error.

**Problem:** When bumping nextra-theme-docs from 4.2.17 to 4.6.1, the docs build fails with:
```
Error: Invalid input: expected nonoptional, received undefined
   → at children
```

**Root cause:** nextra-theme-docs 4.6.1 declares LayoutPropsSchema.children as required but destructures it away before validation (so it's undefined at parse time). zod 4.4+ rejects undefined for required fields before running custom() predicates, but zod 4.1.x still runs the predicate which returns true for undefined.

Since nextra only requires `^4.1.12`, npm resolves to the latest 4.4+. This override pins it to 4.1.12 as a workaround for the upstream bug.

**Verification:** npm install succeeds, zod resolves to 4.1.12 in package-lock.json.