### PR TITLE
fix(executors): grant impersonate so Query spec.serviceAccount is honoured

### DIFF
--- a/executors/claude-agent-sdk/chart/templates/rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/rbac.yaml
@@ -18,13 +18,18 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if .Values.rbac.impersonation.enabled }}
+  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
-  # to resolve the agent, model and their secrets. Without this the resolution
-  # fails rather than falling back to this executor's own identity.
+  # to resolve the agent, model and their secrets. Restricted to an allow-list:
+  # this token is reachable by anything running in the executor, so an
+  # unscoped grant would let it assume a privileged account in the namespace.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
+    {{- if not .Values.rbac.impersonation.allowAny }}
+    resourceNames:
+      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+    {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/executors/claude-agent-sdk/chart/templates/rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/rbac.yaml
@@ -18,6 +18,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
+  {{- if .Values.rbac.impersonation.enabled }}
+  # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
+  # to resolve the agent, model and their secrets. Without this the resolution
+  # fails rather than falling back to this executor's own identity.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/executors/claude-agent-sdk/chart/templates/rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/rbac.yaml
@@ -18,7 +18,8 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
+  {{- $impersonation := .Values.rbac.impersonation | default dict }}
+  {{- if or $impersonation.allowAny $impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
   # to resolve the agent, model and their secrets. Restricted to an allow-list:
   # this token is reachable by anything running in the executor, so an
@@ -26,9 +27,9 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
-    {{- if not .Values.rbac.impersonation.allowAny }}
+    {{- if not $impersonation.allowAny }}
     resourceNames:
-      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+      {{- toYaml ($impersonation.serviceAccountNames | default list) | nindent 6 }}
     {{- end }}
   {{- end }}
 ---

--- a/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
@@ -34,13 +34,18 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if .Values.rbac.impersonation.enabled }}
+  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
-  # to resolve the agent, model and their secrets. Without this the resolution
-  # fails rather than falling back to this sandbox's own identity.
+  # to resolve the agent, model and their secrets. Restricted to an allow-list:
+  # this token is mounted into a pod running model-directed code, so an unscoped
+  # grant would let that code assume a privileged account in the namespace.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
+    {{- if not .Values.rbac.impersonation.allowAny }}
+    resourceNames:
+      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+    {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
@@ -34,6 +34,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
+  {{- if .Values.rbac.impersonation.enabled }}
+  # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
+  # to resolve the agent, model and their secrets. Without this the resolution
+  # fails rather than falling back to this sandbox's own identity.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
+++ b/executors/claude-agent-sdk/chart/templates/sandbox-rbac.yaml
@@ -34,7 +34,8 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
+  {{- $impersonation := .Values.rbac.impersonation | default dict }}
+  {{- if or $impersonation.allowAny $impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
   # to resolve the agent, model and their secrets. Restricted to an allow-list:
   # this token is mounted into a pod running model-directed code, so an unscoped
@@ -42,9 +43,9 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
-    {{- if not .Values.rbac.impersonation.allowAny }}
+    {{- if not $impersonation.allowAny }}
     resourceNames:
-      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+      {{- toYaml ($impersonation.serviceAccountNames | default list) | nindent 6 }}
     {{- end }}
   {{- end }}
 ---

--- a/executors/claude-agent-sdk/chart/values.schema.json
+++ b/executors/claude-agent-sdk/chart/values.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "impersonation": {
+          "type": "object",
+          "properties": {
+            "serviceAccountNames": {
+              "type": ["array", "null"],
+              "items": { "type": "string" }
+            },
+            "allowAny": { "type": ["boolean", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/executors/claude-agent-sdk/chart/values.yaml
+++ b/executors/claude-agent-sdk/chart/values.yaml
@@ -156,6 +156,10 @@ rbac:
     #   serviceAccountNames:
     #     - tenant-a-sa
     #     - tenant-b-sa
+    #
+    # Must be a list. A bare --set value renders a string and the Role is
+    # rejected on apply, so wrap it in braces:
+    #   --set 'rbac.impersonation.serviceAccountNames={tenant-a-sa,tenant-b-sa}'
     serviceAccountNames: []
 
     # Allow assuming ANY ServiceAccount in the namespace instead of the list

--- a/executors/claude-agent-sdk/chart/values.yaml
+++ b/executors/claude-agent-sdk/chart/values.yaml
@@ -145,16 +145,24 @@ rbac:
   create: true
   # Service account impersonation for per-query RBAC scoping.
   #
-  # When enabled (default), the executor resolves a Query's agent, model and
-  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
-  # identity the Ark controller uses for the same field. Queries that do not set
-  # it are resolved with the executor's own service account, as before.
-  #
-  # When disabled, queries that set spec.serviceAccount fail rather than
-  # resolving with the executor's identity — a declared restriction that cannot
-  # be applied is an error, not a default.
+  # A Query may name a ServiceAccount in spec.serviceAccount; the executor then
+  # resolves that query's agent, model and secrets as that account instead of its
+  # own. Queries that do not set the field are unaffected.
   impersonation:
-    enabled: true
+    # ServiceAccounts this executor is allowed to assume, as an explicit
+    # allow-list. Empty (the default) grants nothing, so a query naming a
+    # ServiceAccount fails until an operator opts in by listing it here.
+    #
+    #   serviceAccountNames:
+    #     - tenant-a-sa
+    #     - tenant-b-sa
+    serviceAccountNames: []
+
+    # Allow assuming ANY ServiceAccount in the namespace instead of the list
+    # above. Anything that can reach this pod's token can then act as any account
+    # in the namespace, including a privileged one — and for the sandbox that
+    # token is mounted alongside model-directed code. Prefer serviceAccountNames.
+    allowAny: false
 
 # Service account configuration
 serviceAccount:

--- a/executors/claude-agent-sdk/chart/values.yaml
+++ b/executors/claude-agent-sdk/chart/values.yaml
@@ -143,6 +143,18 @@ networkPolicy:
 # RBAC configuration
 rbac:
   create: true
+  # Service account impersonation for per-query RBAC scoping.
+  #
+  # When enabled (default), the executor resolves a Query's agent, model and
+  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
+  # identity the Ark controller uses for the same field. Queries that do not set
+  # it are resolved with the executor's own service account, as before.
+  #
+  # When disabled, queries that set spec.serviceAccount fail rather than
+  # resolving with the executor's identity — a declared restriction that cannot
+  # be applied is an error, not a default.
+  impersonation:
+    enabled: true
 
 # Service account configuration
 serviceAccount:

--- a/executors/langchain/chart/templates/rbac.yaml
+++ b/executors/langchain/chart/templates/rbac.yaml
@@ -18,13 +18,18 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if .Values.rbac.impersonation.enabled }}
+  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
-  # to resolve the agent, model and their secrets. Without this the resolution
-  # fails rather than falling back to this executor's own identity.
+  # to resolve the agent, model and their secrets. Restricted to an allow-list:
+  # this token is reachable by anything running in the executor, so an
+  # unscoped grant would let it assume a privileged account in the namespace.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
+    {{- if not .Values.rbac.impersonation.allowAny }}
+    resourceNames:
+      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+    {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/executors/langchain/chart/templates/rbac.yaml
+++ b/executors/langchain/chart/templates/rbac.yaml
@@ -18,6 +18,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
+  {{- if .Values.rbac.impersonation.enabled }}
+  # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
+  # to resolve the agent, model and their secrets. Without this the resolution
+  # fails rather than falling back to this executor's own identity.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/executors/langchain/chart/templates/rbac.yaml
+++ b/executors/langchain/chart/templates/rbac.yaml
@@ -18,7 +18,8 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
+  {{- $impersonation := .Values.rbac.impersonation | default dict }}
+  {{- if or $impersonation.allowAny $impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
   # to resolve the agent, model and their secrets. Restricted to an allow-list:
   # this token is reachable by anything running in the executor, so an
@@ -26,9 +27,9 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
-    {{- if not .Values.rbac.impersonation.allowAny }}
+    {{- if not $impersonation.allowAny }}
     resourceNames:
-      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+      {{- toYaml ($impersonation.serviceAccountNames | default list) | nindent 6 }}
     {{- end }}
   {{- end }}
 ---

--- a/executors/langchain/chart/values.schema.json
+++ b/executors/langchain/chart/values.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "impersonation": {
+          "type": "object",
+          "properties": {
+            "serviceAccountNames": {
+              "type": ["array", "null"],
+              "items": { "type": "string" }
+            },
+            "allowAny": { "type": ["boolean", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/executors/langchain/chart/values.yaml
+++ b/executors/langchain/chart/values.yaml
@@ -49,16 +49,24 @@ rbac:
   create: true
   # Service account impersonation for per-query RBAC scoping.
   #
-  # When enabled (default), the executor resolves a Query's agent, model and
-  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
-  # identity the Ark controller uses for the same field. Queries that do not set
-  # it are resolved with the executor's own service account, as before.
-  #
-  # When disabled, queries that set spec.serviceAccount fail rather than
-  # resolving with the executor's identity — a declared restriction that cannot
-  # be applied is an error, not a default.
+  # A Query may name a ServiceAccount in spec.serviceAccount; the executor then
+  # resolves that query's agent, model and secrets as that account instead of its
+  # own. Queries that do not set the field are unaffected.
   impersonation:
-    enabled: true
+    # ServiceAccounts this executor is allowed to assume, as an explicit
+    # allow-list. Empty (the default) grants nothing, so a query naming a
+    # ServiceAccount fails until an operator opts in by listing it here.
+    #
+    #   serviceAccountNames:
+    #     - tenant-a-sa
+    #     - tenant-b-sa
+    serviceAccountNames: []
+
+    # Allow assuming ANY ServiceAccount in the namespace instead of the list
+    # above. Anything that can reach this pod's token can then act as any account
+    # in the namespace, including a privileged one — and for the sandbox that
+    # token is mounted alongside model-directed code. Prefer serviceAccountNames.
+    allowAny: false
 
 # Service account configuration
 serviceAccount:

--- a/executors/langchain/chart/values.yaml
+++ b/executors/langchain/chart/values.yaml
@@ -47,6 +47,18 @@ httpRoute:
 # RBAC configuration
 rbac:
   create: true
+  # Service account impersonation for per-query RBAC scoping.
+  #
+  # When enabled (default), the executor resolves a Query's agent, model and
+  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
+  # identity the Ark controller uses for the same field. Queries that do not set
+  # it are resolved with the executor's own service account, as before.
+  #
+  # When disabled, queries that set spec.serviceAccount fail rather than
+  # resolving with the executor's identity — a declared restriction that cannot
+  # be applied is an error, not a default.
+  impersonation:
+    enabled: true
 
 # Service account configuration
 serviceAccount:

--- a/executors/langchain/chart/values.yaml
+++ b/executors/langchain/chart/values.yaml
@@ -60,6 +60,10 @@ rbac:
     #   serviceAccountNames:
     #     - tenant-a-sa
     #     - tenant-b-sa
+    #
+    # Must be a list. A bare --set value renders a string and the Role is
+    # rejected on apply, so wrap it in braces:
+    #   --set 'rbac.impersonation.serviceAccountNames={tenant-a-sa,tenant-b-sa}'
     serviceAccountNames: []
 
     # Allow assuming ANY ServiceAccount in the namespace instead of the list

--- a/executors/openai-responses/chart/templates/rbac.yaml
+++ b/executors/openai-responses/chart/templates/rbac.yaml
@@ -18,13 +18,18 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if .Values.rbac.impersonation.enabled }}
+  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
-  # to resolve the agent, model and their secrets. Without this the resolution
-  # fails rather than falling back to this executor's own identity.
+  # to resolve the agent, model and their secrets. Restricted to an allow-list:
+  # this token is reachable by anything running in the executor, so an
+  # unscoped grant would let it assume a privileged account in the namespace.
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
+    {{- if not .Values.rbac.impersonation.allowAny }}
+    resourceNames:
+      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+    {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/executors/openai-responses/chart/templates/rbac.yaml
+++ b/executors/openai-responses/chart/templates/rbac.yaml
@@ -18,6 +18,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
+  {{- if .Values.rbac.impersonation.enabled }}
+  # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
+  # to resolve the agent, model and their secrets. Without this the resolution
+  # fails rather than falling back to this executor's own identity.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/executors/openai-responses/chart/templates/rbac.yaml
+++ b/executors/openai-responses/chart/templates/rbac.yaml
@@ -18,7 +18,8 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps", "services"]
     verbs: ["get"]
-  {{- if or .Values.rbac.impersonation.allowAny .Values.rbac.impersonation.serviceAccountNames }}
+  {{- $impersonation := .Values.rbac.impersonation | default dict }}
+  {{- if or $impersonation.allowAny $impersonation.serviceAccountNames }}
   # A Query may name a ServiceAccount in spec.serviceAccount, which the SDK uses
   # to resolve the agent, model and their secrets. Restricted to an allow-list:
   # this token is reachable by anything running in the executor, so an
@@ -26,9 +27,9 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["impersonate"]
-    {{- if not .Values.rbac.impersonation.allowAny }}
+    {{- if not $impersonation.allowAny }}
     resourceNames:
-      {{- toYaml .Values.rbac.impersonation.serviceAccountNames | nindent 6 }}
+      {{- toYaml ($impersonation.serviceAccountNames | default list) | nindent 6 }}
     {{- end }}
   {{- end }}
 ---

--- a/executors/openai-responses/chart/values.schema.json
+++ b/executors/openai-responses/chart/values.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "impersonation": {
+          "type": "object",
+          "properties": {
+            "serviceAccountNames": {
+              "type": ["array", "null"],
+              "items": { "type": "string" }
+            },
+            "allowAny": { "type": ["boolean", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/executors/openai-responses/chart/values.yaml
+++ b/executors/openai-responses/chart/values.yaml
@@ -62,6 +62,10 @@ rbac:
     #   serviceAccountNames:
     #     - tenant-a-sa
     #     - tenant-b-sa
+    #
+    # Must be a list. A bare --set value renders a string and the Role is
+    # rejected on apply, so wrap it in braces:
+    #   --set 'rbac.impersonation.serviceAccountNames={tenant-a-sa,tenant-b-sa}'
     serviceAccountNames: []
 
     # Allow assuming ANY ServiceAccount in the namespace instead of the list

--- a/executors/openai-responses/chart/values.yaml
+++ b/executors/openai-responses/chart/values.yaml
@@ -51,16 +51,24 @@ rbac:
   create: true
   # Service account impersonation for per-query RBAC scoping.
   #
-  # When enabled (default), the executor resolves a Query's agent, model and
-  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
-  # identity the Ark controller uses for the same field. Queries that do not set
-  # it are resolved with the executor's own service account, as before.
-  #
-  # When disabled, queries that set spec.serviceAccount fail rather than
-  # resolving with the executor's identity — a declared restriction that cannot
-  # be applied is an error, not a default.
+  # A Query may name a ServiceAccount in spec.serviceAccount; the executor then
+  # resolves that query's agent, model and secrets as that account instead of its
+  # own. Queries that do not set the field are unaffected.
   impersonation:
-    enabled: true
+    # ServiceAccounts this executor is allowed to assume, as an explicit
+    # allow-list. Empty (the default) grants nothing, so a query naming a
+    # ServiceAccount fails until an operator opts in by listing it here.
+    #
+    #   serviceAccountNames:
+    #     - tenant-a-sa
+    #     - tenant-b-sa
+    serviceAccountNames: []
+
+    # Allow assuming ANY ServiceAccount in the namespace instead of the list
+    # above. Anything that can reach this pod's token can then act as any account
+    # in the namespace, including a privileged one — and for the sandbox that
+    # token is mounted alongside model-directed code. Prefer serviceAccountNames.
+    allowAny: false
 
 # Service account configuration
 serviceAccount:

--- a/executors/openai-responses/chart/values.yaml
+++ b/executors/openai-responses/chart/values.yaml
@@ -49,6 +49,18 @@ httpRoute:
 # RBAC configuration
 rbac:
   create: true
+  # Service account impersonation for per-query RBAC scoping.
+  #
+  # When enabled (default), the executor resolves a Query's agent, model and
+  # secrets as the ServiceAccount named in its spec.serviceAccount, matching the
+  # identity the Ark controller uses for the same field. Queries that do not set
+  # it are resolved with the executor's own service account, as before.
+  #
+  # When disabled, queries that set spec.serviceAccount fail rather than
+  # resolving with the executor's identity — a declared restriction that cannot
+  # be applied is an error, not a default.
+  impersonation:
+    enabled: true
 
 # Service account configuration
 serviceAccount:


### PR DESCRIPTION
## Summary

- Lets an executor resolve a Query's agent, model and secrets as the ServiceAccount
  the Query names in `spec.serviceAccount`, which requires `impersonate` on
  `serviceaccounts`. Needed for mckinsey/agents-at-scale-ark#3353 to have any
  effect.
- The grant is an explicit allow-list: `rbac.impersonation.serviceAccountNames`
  renders as `resourceNames` on the Role. **Empty by default**, which grants
  nothing — a query naming a ServiceAccount fails until an operator opts in by
  listing it. `rbac.impersonation.allowAny` permits any account in the namespace
  and is off by default.
- Scoping matters because an unscoped grant lets anything holding an executor's
  token assume any ServiceAccount in the namespace, including a privileged one.
  That is worse than the executor's existing namespace-wide secret read, since a
  privileged account adds write access — and for the sandbox the token is mounted
  alongside model-directed code.
- Four Role files, not three: `claude-agent-sdk` has a second `sandbox-ark-reader`
  Role whose pod runs the same executor image and so resolves queries too. The
  scheduler Role is untouched — different image, and it only patches
  `queries/status`.
- Verified on a cluster: with `serviceAccountNames={tenant-a-sa,tenant-b-sa}` the
  executor can impersonate those two and is denied `default` and `ark-api-sa`; a
  query naming a non-listed account fails with 403 rather than resolving. Default
  values render no impersonation rule in any of the four Roles.

Existing installs are unaffected until they both bump the executor image to an
`ark-sdk` carrying the core change and configure `serviceAccountNames`. Queries
that don't set `spec.serviceAccount` are unaffected either way.

