### PR TITLE
fix:  CVE-2026-84394 and CVE-2026-84292

### DIFF
--- a/mcps/filesystem-mcp-server/package-lock.json
+++ b/mcps/filesystem-mcp-server/package-lock.json
@@ -1386,6 +1386,22 @@
         }
       }
     },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1826,22 +1842,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",

--- a/mcps/filesystem-mcp-server/package.json
+++ b/mcps/filesystem-mcp-server/package.json
@@ -33,6 +33,7 @@
   },
   "overrides": {
     "qs": ">=6.15.2",
-    "zod-to-json-schema": "3.23.5"
+    "zod-to-json-schema": "3.23.5",
+    "fast-uri": "3.1.7"
   }
 }


### PR DESCRIPTION
Summary

- JFrog Xray flagged two new High-severity CVEs against mcps/filesystem-mcp-server: CVE-2026-84394 (XRAY-1068524) and CVE-2026-84292 (XRAY-1068530), both in fast-uri@3.1.6 — SSRF-adjacent bugs in host/port parsing that let a crafted URI resolve to a different host than validated.
- fast-uri is a transitive dep (@modelcontextprotocol/sdk → ajv/ajv-formats → fast-uri), not a direct one, so it's pinned via the existing overrides block in package.json rather than added as a direct dependency.
- Pinned to 3.1.7 (not the latest 4.1.4) to stay within the major version ajv@^3.0.1 actually expects, avoiding an unvetted major bump. Both 3.1.7 and 4.1.4 are listed as fixed versions for these CVEs.