### PR TITLE
fix(file-gateway): stop minting a new PVC on every upgrade

### DIFF
--- a/services/file-gateway/chart/templates/_helpers.tpl
+++ b/services/file-gateway/chart/templates/_helpers.tpl
@@ -112,14 +112,21 @@ Generate S3 secret access key - autogenerate if empty
 {{- end }}
 
 {{/*
-PVC name - use provided name or generate with timestamp suffix
+PVC name - use provided name, else a stable name derived from the release.
+
+Must not depend on `now`: that renders a new name on every `helm upgrade`, so each
+upgrade provisions a fresh PVC and abandons the previous one along with its EBS
+volume. One namespace accumulated 8 such PVCs, of which 2 were in use.
+
+Existing releases installed before this change hold a timestamped PVC. Set
+`storage.pvcName` to that exact name to keep it, otherwise the upgrade renders the
+new stable name and Helm removes the old claim and its data.
 */}}
 {{- define "file-gateway.pvcName" -}}
 {{- if .Values.storage.pvcName }}
 {{- .Values.storage.pvcName }}
 {{- else }}
-{{- $timestamp := now | date "20060102150405" }}
-{{- printf "%s-storage-%s" (include "file-gateway.fullname" .) $timestamp }}
+{{- printf "%s-storage" (include "file-gateway.fullname" .) }}
 {{- end }}
 {{- end }}
 

--- a/services/file-gateway/chart/tests/pvc-name-stable.sh
+++ b/services/file-gateway/chart/tests/pvc-name-stable.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# The PVC name must be stable across renders. It used to embed `now`, so every
+# helm upgrade minted a new PVC and abandoned the previous one plus its EBS volume.
+#
+# Run: services/file-gateway/chart/tests/pvc-name-stable.sh
+set -euo pipefail
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+
+name() { helm template fg "$CHART" ${1:+--set storage.pvcName="$1"} \
+  | awk '/kind: PersistentVolumeClaim/{f=1} f&&/^  name:/{print $2; exit}'; }
+
+A=$(name); sleep 1.1; B=$(name)   # >1s apart: a "20060102150405" suffix would differ
+[ "$A" = "$B" ] || { echo "FAIL: PVC name unstable across renders: '$A' != '$B'"; exit 1; }
+[ "$A" = "file-gateway-storage" ] || { echo "FAIL: expected 'file-gateway-storage', got '$A'"; exit 1; }
+
+OVERRIDE=$(name "file-gateway-storage-20260510143032")
+[ "$OVERRIDE" = "file-gateway-storage-20260510143032" ] || {
+  echo "FAIL: storage.pvcName override ignored, got '$OVERRIDE'"; exit 1; }
+
+echo "PASS: stable default '$A'; override honoured (existing releases can pin their PVC)"

--- a/services/file-gateway/chart/values.yaml
+++ b/services/file-gateway/chart/values.yaml
@@ -10,6 +10,11 @@ storage:
   storageClassName: ""
   accessModes:
     - ReadWriteOnce
+  # Empty means "<fullname>-storage", stable across upgrades. Releases installed
+  # before that became the default hold a timestamped PVC
+  # (file-gateway-storage-20260510143032 and similar) - pin that exact name here,
+  # or the next upgrade renders the new name and Helm deletes the old claim and
+  # its data.
   pvcName: ""
 
 httpRoute:


### PR DESCRIPTION
`file-gateway.pvcName` embedded `now | date "20060102150405"`, so every `helm upgrade` rendered a different PVC name. Each upgrade provisioned a fresh PVC and abandoned the previous one along with its EBS volume. One namespace on a demo cluster accumulated **8** `file-gateway-storage-*` PVCs, 2 mounted; the strays surfaced as Wiz *"EBS volume should be encrypted with a customer-managed key"* findings on volumes nothing was using.

## Change

- Default is now the stable `<fullname>-storage`. `storage.pvcName` still wins.
- `chart/tests/pvc-name-stable.sh` renders twice >1 s apart and asserts the name is identical, is the expected default, and that the override is honoured. It **fails against the previous helper** (`…104329 != …104330`) and passes now. `helm lint` clean.

## ⚠️ Upgrade hazard — read before merging

Any existing release still using the timestamped default will, on its next upgrade with this chart, render `file-gateway-storage`, and **Helm will delete the old PVC and its data.**

Before upgrading such a release, set `storage.pvcName` to its current claim. Known live releases needing a pin (one cluster fleet; others may exist):

| Namespace | Pin to |
|---|---|
| kyc-demo (mgmt) | `file-gateway-storage-20260216140511` |
| kyc-demo (demo) | `file-gateway-storage-20260510143032` ✅ pinned in ark-management, and `file-gateway-storage-20260408181031` |
| default (demo) | `file-gateway-storage-20260327135733` |
| onboarding-demo | `file-gateway-storage-20260625105330` |
| onboarding (test) | `file-gateway-storage-20260619123500` |
| default (pen-test) | `file-gateway-storage-20260721194247` |

Releases already on plain `file-gateway-storage` (cobol-demo, commercial-lines-underwriting, kyc-onboarding-demo) match the new default and need nothing.

Suggest a CHANGELOG entry flagging this as a breaking change for release-please.